### PR TITLE
fix: use milliseconds for timestamps

### DIFF
--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -209,7 +209,7 @@ func (k Keeper) SetBridgeValidatorParams(ctx context.Context, bridgeValidatorSet
 	powerThreshold := totalPower * 2 / 3
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	validatorTimestamp := uint64(sdkCtx.BlockTime().Unix())
+	validatorTimestamp := uint64(sdkCtx.BlockTime().UnixMilli())
 
 	// calculate validator set hash
 	_, validatorSetHash, err := k.EncodeAndHashValidatorSet(ctx, bridgeValidatorSet)
@@ -781,12 +781,12 @@ func (k Keeper) CreateSnapshot(ctx context.Context, queryId []byte, timestamp ti
 	snapshotBytes, err := k.EncodeOracleAttestationData(
 		queryId,
 		aggReport.AggregateValue,
-		timestamp.Unix(),
+		timestamp.UnixMilli(),
 		aggReport.ReporterPower,
-		tsBefore.Unix(),
-		tsAfter.Unix(),
+		tsBefore.UnixMilli(),
+		tsAfter.UnixMilli(),
 		validatorCheckpoint.Checkpoint,
-		attestationTimestamp.Unix(),
+		attestationTimestamp.UnixMilli(),
 	)
 	if err != nil {
 		k.Logger(ctx).Info("Error encoding oracle attestation data", "error", err)
@@ -794,7 +794,7 @@ func (k Keeper) CreateSnapshot(ctx context.Context, queryId []byte, timestamp ti
 	}
 
 	// set snapshot by report
-	key := crypto.Keccak256([]byte(hex.EncodeToString(queryId) + fmt.Sprint(timestamp.Unix())))
+	key := crypto.Keccak256([]byte(hex.EncodeToString(queryId) + fmt.Sprint(timestamp.UnixMilli())))
 	// check if map for this key exists, otherwise create a new map
 	exists, err := k.AttestSnapshotsByReportMap.Has(ctx, key)
 	if err != nil {
@@ -825,11 +825,11 @@ func (k Keeper) CreateSnapshot(ctx context.Context, queryId []byte, timestamp ti
 	// set snapshot to snapshot data map
 	snapshotData := types.AttestationSnapshotData{
 		ValidatorCheckpoint:  validatorCheckpoint.Checkpoint,
-		AttestationTimestamp: attestationTimestamp.Unix(),
-		PrevReportTimestamp:  tsBefore.Unix(),
-		NextReportTimestamp:  tsAfter.Unix(),
+		AttestationTimestamp: attestationTimestamp.UnixMilli(),
+		PrevReportTimestamp:  tsBefore.UnixMilli(),
+		NextReportTimestamp:  tsAfter.UnixMilli(),
 		QueryId:              queryId,
-		Timestamp:            timestamp.Unix(),
+		Timestamp:            timestamp.UnixMilli(),
 	}
 	err = k.AttestSnapshotDataMap.Set(ctx, snapshotBytes, snapshotData)
 	if err != nil {

--- a/x/bridge/keeper/query_get_current_aggregate_report.go
+++ b/x/bridge/keeper/query_get_current_aggregate_report.go
@@ -22,7 +22,7 @@ func (q Querier) GetCurrentAggregateReport(ctx context.Context, req *types.Query
 	if aggregate == nil {
 		return nil, status.Error(codes.NotFound, "aggregate not found")
 	}
-	timeUnix := timestamp.Unix()
+	timeUnix := timestamp.UnixMilli()
 
 	// convert oracletypes.Reporters to bridgetypes.Reporters
 	convertedReporters := make([]*types.AggregateReporter, len(aggregate.Reporters))

--- a/x/bridge/keeper/query_get_data_before.go
+++ b/x/bridge/keeper/query_get_data_before.go
@@ -27,7 +27,7 @@ func (q Querier) GetDataBefore(ctx context.Context, req *types.QueryGetDataBefor
 	if aggregate == nil {
 		return nil, status.Error(codes.NotFound, "aggregate before not found")
 	}
-	timeUnix := timestamp.Unix()
+	timeUnix := timestamp.UnixMilli()
 
 	return &types.QueryGetDataBeforeResponse{
 		Aggregate: aggregate,

--- a/x/bridge/keeper/query_get_snapshots_by_report.go
+++ b/x/bridge/keeper/query_get_snapshots_by_report.go
@@ -29,7 +29,7 @@ func (q Querier) GetSnapshotsByReport(ctx context.Context, req *types.QueryGetSn
 	}
 	timestampTime := time.Unix(timestampInt, 0)
 
-	key := crypto.Keccak256([]byte(hex.EncodeToString(queryIdBytes) + fmt.Sprint(timestampTime.Unix())))
+	key := crypto.Keccak256([]byte(hex.EncodeToString(queryIdBytes) + fmt.Sprint(timestampTime.UnixMilli())))
 	snapshots, err := q.k.AttestSnapshotsByReportMap.Get(ctx, key)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("snapshots not found for queryId %s and timestamp %s", queryIdStr, timestampStr))

--- a/x/oracle/keeper/aggregate.go
+++ b/x/oracle/keeper/aggregate.go
@@ -109,7 +109,7 @@ func (k Keeper) SetAggregate(ctx context.Context, report *types.Aggregate) error
 	report.Nonce = nonce
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	currentTimestamp := sdkCtx.BlockTime().Unix()
+	currentTimestamp := sdkCtx.BlockTime().UnixMilli()
 	report.Height = sdkCtx.BlockHeight()
 
 	return k.Aggregates.Set(ctx, collections.Join(report.QueryId, currentTimestamp), *report)
@@ -117,7 +117,7 @@ func (k Keeper) SetAggregate(ctx context.Context, report *types.Aggregate) error
 
 // getDataBefore returns the last aggregate before or at the given timestamp for the given query id.
 func (k Keeper) GetDataBefore(ctx context.Context, queryId []byte, timestamp time.Time) (*types.Aggregate, error) {
-	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).EndInclusive(timestamp.Unix()).Descending()
+	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).EndInclusive(timestamp.UnixMilli()).Descending()
 	var mostRecent *types.Aggregate
 	// This should get us the most recent aggregate, as they are walked in descending order
 	err := k.Aggregates.Walk(ctx, rng, func(key collections.Pair[[]byte, int64], value types.Aggregate) (stop bool, err error) {
@@ -154,7 +154,7 @@ func (k Keeper) GetCurrentValueForQueryId(ctx context.Context, queryId []byte) (
 }
 
 func (k Keeper) GetTimestampBefore(ctx context.Context, queryId []byte, timestamp time.Time) (time.Time, error) {
-	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).EndExclusive(timestamp.Unix()).Descending()
+	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).EndExclusive(timestamp.UnixMilli()).Descending()
 	var mostRecent int64
 	err := k.Aggregates.Walk(ctx, rng, func(key collections.Pair[[]byte, int64], value types.Aggregate) (stop bool, err error) {
 		mostRecent = key.K2()
@@ -172,7 +172,7 @@ func (k Keeper) GetTimestampBefore(ctx context.Context, queryId []byte, timestam
 }
 
 func (k Keeper) GetTimestampAfter(ctx context.Context, queryId []byte, timestamp time.Time) (time.Time, error) {
-	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).StartExclusive(timestamp.Unix())
+	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).StartExclusive(timestamp.UnixMilli())
 	var mostRecent int64
 	err := k.Aggregates.Walk(ctx, rng, func(key collections.Pair[[]byte, int64], value types.Aggregate) (stop bool, err error) {
 		mostRecent = key.K2()
@@ -223,7 +223,7 @@ func (k Keeper) GetCurrentAggregateReport(ctx context.Context, queryId []byte) (
 
 func (k Keeper) GetAggregateBefore(ctx context.Context, queryId []byte, timestampBefore time.Time) (aggregate *types.Aggregate, timestamp time.Time, err error) {
 	// Convert the timestampBefore to Unix time and create a range that ends just before this timestamp
-	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).EndExclusive(timestampBefore.Unix()).Descending()
+	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).EndExclusive(timestampBefore.UnixMilli()).Descending()
 
 	var mostRecent *types.Aggregate
 	var mostRecentTimestamp int64
@@ -248,7 +248,7 @@ func (k Keeper) GetAggregateBefore(ctx context.Context, queryId []byte, timestam
 }
 
 func (k Keeper) GetAggregateByTimestamp(ctx context.Context, queryId []byte, timestamp time.Time) (aggregate *types.Aggregate, err error) {
-	timestampUnix := timestamp.Unix()
+	timestampUnix := timestamp.UnixMilli()
 
 	// Create a range that specifically targets the exact timestamp
 	rng := collections.NewPrefixedPairRange[[]byte, int64](queryId).StartInclusive(timestampUnix).EndInclusive(timestampUnix)


### PR DESCRIPTION
If we aim to have sub-second blocks, we need to make sure we are storing times with the right precision.