### PR TITLE
use legacy dec for division

### DIFF
--- a/daemons/token_bridge_feed/client/client.go
+++ b/daemons/token_bridge_feed/client/client.go
@@ -134,13 +134,26 @@ func (c *Client) QueryAPI(urlStr string) ([]byte, error) {
 }
 
 func (c *Client) InitializeDeposits() error {
-	ethRpcUrl, err := c.getEthRpcUrl()
-	if err != nil {
-		return fmt.Errorf("failed to get ETH RPC url: %w", err)
+	// Add retry logic for initial connection
+	var eclient *ethclient.Client
+	var err error
+	var ethRpcUrl string
+	for retries := 0; retries < 3; retries++ {
+		ethRpcUrl, err = c.getEthRpcUrl()
+		if err != nil {
+			return fmt.Errorf("failed to get ETH RPC url: %w", err)
+		}
+
+		eclient, err = ethclient.Dial(ethRpcUrl)
+		if err != nil {
+			c.logger.Error("Failed to connect to Ethereum client, retrying...", "attempt", retries+1, "error", err)
+			time.Sleep(time.Second * 5)
+			continue
+		}
+		break
 	}
-	eclient, err := ethclient.Dial(ethRpcUrl)
 	if err != nil {
-		return fmt.Errorf("failed to connect to the Ethereum client: %w", err)
+		return fmt.Errorf("failed to connect to the Ethereum client after retries: %w", err)
 	}
 
 	c.ethClient = eclient
@@ -168,9 +181,27 @@ func (c *Client) InitializeDeposits() error {
 }
 
 func (c *Client) QueryTokenBridgeContract() error {
-	latestDepositId, err := c.QueryCurrentDepositId()
-	if err != nil {
-		return fmt.Errorf("failed to query the latest deposit ID: %w", err)
+	// Add retry logic for queries
+	var latestDepositId *big.Int
+	var err error
+
+	for retries := 0; retries < 3; retries++ {
+		latestDepositId, err = c.QueryCurrentDepositId()
+		if err != nil {
+			if retries < 2 {
+				c.logger.Error("Failed to query latest deposit ID, reconnecting...", "attempt", retries+1, "error", err)
+				// Attempt to reconnect
+				if err := c.reconnectEthClient(); err != nil {
+					c.logger.Error("Failed to reconnect", "error", err)
+					time.Sleep(time.Second * 5)
+					continue
+				}
+			} else {
+				return fmt.Errorf("failed to query the latest deposit ID: %w", err)
+			}
+		} else {
+			break
+		}
 	}
 
 	if c.lastReportedDepositId == nil {
@@ -377,4 +408,38 @@ func (c *Client) getTokenBridgeContractAddress() (common.Address, error) {
 		return common.Address{}, fmt.Errorf("token_bridge_contract not set")
 	}
 	return common.HexToAddress(tokenBridgeContractAddress), nil
+}
+
+// Add new helper function for reconnection
+func (c *Client) reconnectEthClient() error {
+	ethRpcUrl, err := c.getEthRpcUrl()
+	if err != nil {
+		return fmt.Errorf("failed to get ETH RPC url: %w", err)
+	}
+
+	eclient, err := ethclient.Dial(ethRpcUrl)
+	if err != nil {
+		return fmt.Errorf("failed to reconnect to the Ethereum client: %w", err)
+	}
+
+	// Close existing client if it exists
+	if c.ethClient != nil {
+		c.ethClient.Close()
+	}
+
+	c.ethClient = eclient
+
+	// Reinstantiate the bridge contract with new client
+	contractAddress, err := c.getTokenBridgeContractAddress()
+	if err != nil {
+		return fmt.Errorf("failed to get token bridge contract address: %w", err)
+	}
+
+	bridgeContract, err := tokenbridge.NewTokenBridge(contractAddress, c.ethClient)
+	if err != nil {
+		return fmt.Errorf("failed to reinstantiate TokenBridge contract: %w", err)
+	}
+
+	c.bridgeContract = bridgeContract
+	return nil
 }

--- a/evm/contracts/bridge/BlobstreamO.sol
+++ b/evm/contracts/bridge/BlobstreamO.sol
@@ -45,6 +45,7 @@ contract BlobstreamO is ECDSA {
     uint256 public validatorTimestamp; /// Timestamp of the block where validator set is updated.
     address public deployer; /// Address that deployed the contract.
     bool public initialized; /// True if the contract is initialized.
+    bool public isTestnet = true; /// True if the contract is on testnet.
 
     /*Events*/
     event ValidatorSetUpdated(uint256 _powerThreshold, uint256 _validatorTimestamp, bytes32 _validatorSetHash);
@@ -58,6 +59,7 @@ contract BlobstreamO is ECDSA {
     error NotConsensusValue();
     error NotDeployer();
     error NotGuardian();
+    error NotTestnet();
     error StaleValidatorSet();
     error SuppliedValidatorSetInvalid();
     error ValidatorSetNotStale();
@@ -116,6 +118,34 @@ contract BlobstreamO is ECDSA {
         powerThreshold = _powerThreshold;
         validatorTimestamp = _validatorTimestamp;
         lastValidatorSetCheckpoint = _validatorSetCheckpoint;
+    }
+
+    /// @notice This function is called by the guardian to reset the validator set
+    /// on testnet. Not to be used on mainnet.
+    /// @param _powerThreshold Amount of voting power needed to approve operations.
+    /// @param _validatorTimestamp The timestamp of the block where validator set is updated.
+    /// @param _validatorSetCheckpoint The hash of the validator set.
+    function guardianResetValidatorSetTestnet(
+        uint256 _powerThreshold,
+        uint256 _validatorTimestamp,
+        bytes32 _validatorSetCheckpoint
+    ) external {
+        if (msg.sender != guardian) {
+            revert NotGuardian();
+        }
+        if (!isTestnet) {
+            revert NotTestnet();
+        }
+        powerThreshold = _powerThreshold;
+        validatorTimestamp = _validatorTimestamp;
+        lastValidatorSetCheckpoint = _validatorSetCheckpoint;
+    }
+
+    function guardianThrowAwayReset() external {
+        if (msg.sender != guardian) {
+            revert NotGuardian();
+        }
+        isTestnet = false;
     }
 
     /// @notice This updates the validator set by checking that the validators

--- a/x/dispute/keeper/claim_reward.go
+++ b/x/dispute/keeper/claim_reward.go
@@ -123,11 +123,21 @@ func (k Keeper) CalculateReward(ctx sdk.Context, addr sdk.AccAddress, id uint64)
 	}
 
 	// normalize powers
-	userPower := addrUserPower.Mul(layer.PowerReduction).Quo(globalUserPower)
-	reporterPower := addrReporterPower.Mul(layer.PowerReduction).Quo(globalReporterPower)
-	tokenholderPower := addrTokenholderPower.Mul(layer.PowerReduction).Quo(globalTokenholderPower)
-	totalAccPower := userPower.Add(reporterPower).Add(tokenholderPower)
-	rewardAcc := totalAccPower.Mul(dispute.VoterReward).Quo(math.NewInt(totalGroups).Mul(layer.PowerReduction))
+	powerReductionDec := math.LegacyNewDecFromInt(layer.PowerReduction)
+	addrUserPowerDec := math.LegacyNewDecFromInt(addrUserPower)
+	addrReporterPowerDec := math.LegacyNewDecFromInt(addrReporterPower)
+	addrTokenholderPowerDec := math.LegacyNewDecFromInt(addrTokenholderPower)
+	globalUserPowerDec := math.LegacyNewDecFromInt(globalUserPower)
+	globalReporterPowerDec := math.LegacyNewDecFromInt(globalReporterPower)
+	globalTokenholderPowerDec := math.LegacyNewDecFromInt(globalTokenholderPower)
+	totalGroupsDec := math.LegacyNewDecFromInt(math.NewInt(totalGroups))
+	disputeVoterRewardDec := math.LegacyNewDecFromInt(dispute.VoterReward)
 
-	return rewardAcc, nil
+	userPower := addrUserPowerDec.Mul(powerReductionDec).Quo(globalUserPowerDec)
+	reporterPower := addrReporterPowerDec.Mul(powerReductionDec).Quo(globalReporterPowerDec)
+	tokenholderPower := addrTokenholderPowerDec.Mul(powerReductionDec).Quo(globalTokenholderPowerDec)
+	totalAccPower := userPower.Add(reporterPower).Add(tokenholderPower)
+	rewardAcc := totalAccPower.Mul(disputeVoterRewardDec).Quo(totalGroupsDec.Mul(powerReductionDec))
+
+	return rewardAcc.TruncateInt(), nil
 }

--- a/x/dispute/keeper/msg_server_withdraw_fee_refund.go
+++ b/x/dispute/keeper/msg_server_withdraw_fee_refund.go
@@ -32,7 +32,9 @@ func (k msgServer) WithdrawFeeRefund(ctx context.Context, msg *types.MsgWithdraw
 	}
 	// handle failed underfunded dispute
 	if dispute.DisputeStatus == types.Failed {
-		feeMinusBurn := dispute.FeeTotal.Quo(math.NewInt(20))
+		disputeFeeTotalDec := math.LegacyNewDecFromInt(dispute.FeeTotal)
+		feeMinusBurnDec := disputeFeeTotalDec.Quo(math.LegacyNewDec(20))
+		feeMinusBurn := feeMinusBurnDec.TruncateInt()
 		fraction, err := k.RefundDisputeFee(ctx, feePayer, payerInfo, dispute.FeeTotal, feeMinusBurn, dispute.HashId)
 		if err != nil {
 			return nil, err
@@ -77,7 +79,10 @@ func (k msgServer) WithdrawFeeRefund(ctx context.Context, msg *types.MsgWithdraw
 
 	}
 
-	burnDust := remainder.Quo(layertypes.PowerReduction)
+	remainderDec := math.LegacyNewDecFromInt(remainder)
+	powerReductionDec := math.LegacyNewDecFromInt(layertypes.PowerReduction)
+	burnDustDec := remainderDec.Quo(powerReductionDec)
+	burnDust := burnDustDec.TruncateInt()
 
 	if !burnDust.IsZero() {
 		if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(layertypes.BondDenom, burnDust))); err != nil {

--- a/x/reporter/keeper/msg_server.go
+++ b/x/reporter/keeper/msg_server.go
@@ -303,7 +303,9 @@ func (k msgServer) WithdrawTip(goCtx context.Context, msg *types.MsgWithdrawTip)
 	if !val.IsBonded() {
 		return nil, errors.New("chosen validator must be bonded")
 	}
-	amtToDelegate := shares.Value.QuoUint64(1e6)
+	sharesDec := k.LegacyDecFromMathUint(shares.Value)
+	amtToDelegateDec := sharesDec.Quo(math.LegacyNewDec(1e6))
+	amtToDelegate := k.TruncateUint(amtToDelegateDec)
 	if amtToDelegate.IsZero() {
 		return nil, errors.New("no tips to withdraw")
 	}

--- a/x/reporter/keeper/withdraw.go
+++ b/x/reporter/keeper/withdraw.go
@@ -260,7 +260,7 @@ func (k Keeper) deductUnbondingDelegation(ctx context.Context, delAddr sdk.AccAd
 			u.Balance = uBalanceDec.TruncateInt()
 
 			uInitialBalanceDec := math.LegacyNewDecFromInt(u.InitialBalance)
-			uInitialBalanceDec = uInitialBalanceDec.Sub(tokensDec).Quo(powerReductionDec)
+			uInitialBalanceDec = uInitialBalanceDec.Sub(tokensDec.Quo(powerReductionDec))
 			u.InitialBalance = uInitialBalanceDec.TruncateInt()
 			ubd.Entries[i] = u
 			removeAmt = removeAmt.Add(tokens)

--- a/x/reporter/keeper/withdraw.go
+++ b/x/reporter/keeper/withdraw.go
@@ -161,7 +161,13 @@ func (k Keeper) EscrowReporterStake(ctx context.Context, reporterAddr sdk.AccAdd
 	leftover := math.NewUint(amt.Uint64() * 1e6)
 	for i, del := range report.TokenOrigins {
 		truncDelAmount := math.NewUint(del.Amount.Uint64()).QuoUint64(layertypes.PowerReduction.Uint64()).MulUint64(layertypes.PowerReduction.Uint64())
-		delegatorShare := truncDelAmount.MulUint64(amt.Uint64()).MulUint64(1e6).Quo(math.NewUint(totalTokens.Uint64()))
+		// convert args needed for calculations to legacy decimals
+		truncDelAmountDec := k.LegacyDecFromMathUint(truncDelAmount)
+		amtDec := math.LegacyNewDecFromInt(amt)
+		powerReductionDec := math.LegacyNewDecFromInt(layertypes.PowerReduction)
+		totalTokensDec := math.LegacyNewDecFromInt(totalTokens)
+		delegatorShareDec := truncDelAmountDec.Mul(amtDec).Mul(powerReductionDec).Quo(totalTokensDec)
+		delegatorShare := k.TruncateUint(delegatorShareDec)
 		leftover = leftover.Sub(delegatorShare)
 
 		if i == len(report.TokenOrigins)-1 {
@@ -176,7 +182,9 @@ func (k Keeper) EscrowReporterStake(ctx context.Context, reporterAddr sdk.AccAdd
 			return err
 		}
 		storedAmount := delegatorShare.Sub(math.NewUint(remaining.Uint64()))
-		storedAmountFixed6 := storedAmount.Quo(math.NewUint(1e6))
+		storedAmountDec := k.LegacyDecFromMathUint(storedAmount)
+		storedAmountFixed6Dec := storedAmountDec.Quo(powerReductionDec)
+		storedAmountFixed6 := k.TruncateUint(storedAmountFixed6Dec)
 		if !storedAmount.IsZero() {
 			disputeTokens = append(disputeTokens, &types.TokenOriginInfo{
 				DelegatorAddress: del.DelegatorAddress,
@@ -185,7 +193,9 @@ func (k Keeper) EscrowReporterStake(ctx context.Context, reporterAddr sdk.AccAdd
 			})
 		}
 
-		remainingFixed6 := remaining.Quo(math.NewUint(1e6))
+		remainingDec := k.LegacyDecFromMathUint(remaining)
+		remainingFixed6Dec := remainingDec.Quo(powerReductionDec)
+		remainingFixed6 := k.TruncateUint(remainingFixed6Dec)
 		if !remaining.IsZero() {
 			dstVAl, err := k.getDstValidator(ctx, delAddr, valAddr)
 			if err != nil {
@@ -243,8 +253,15 @@ func (k Keeper) deductUnbondingDelegation(ctx context.Context, delAddr sdk.AccAd
 			removeAmt = removeAmt.Add(normalizedBalance)
 			ubd.RemoveEntry(int64(i))
 		} else {
-			u.Balance = math.NewIntFromUint64(normalizedBalance.Sub(tokens).QuoUint64(1e6).Uint64())
-			u.InitialBalance = u.InitialBalance.Sub(math.NewIntFromUint64(tokens.QuoUint64(1e6).Uint64()))
+			normalizedBalanceDec := k.LegacyDecFromMathUint(normalizedBalance)
+			tokensDec := k.LegacyDecFromMathUint(tokens)
+			powerReductionDec := math.LegacyNewDecFromInt(layertypes.PowerReduction)
+			uBalanceDec := normalizedBalanceDec.Sub(tokensDec).Quo(powerReductionDec)
+			u.Balance = uBalanceDec.TruncateInt()
+
+			uInitialBalanceDec := math.LegacyNewDecFromInt(u.InitialBalance)
+			uInitialBalanceDec = uInitialBalanceDec.Sub(tokensDec).Quo(powerReductionDec)
+			u.InitialBalance = uInitialBalanceDec.TruncateInt()
 			ubd.Entries[i] = u
 			removeAmt = removeAmt.Add(tokens)
 			tokens = math.ZeroUint()
@@ -260,7 +277,11 @@ func (k Keeper) deductUnbondingDelegation(ctx context.Context, delAddr sdk.AccAd
 	if err != nil {
 		return math.Uint{}, err
 	}
-	err = k.tokensToDispute(ctx, stakingtypes.NotBondedPoolName, (math.NewInt(int64(removeAmt.Uint64())).QuoRaw(1e6)))
+	removeAmtDec := k.LegacyDecFromMathUint(removeAmt)
+	powerReductionDec := math.LegacyNewDecFromInt(layertypes.PowerReduction)
+	disputeAmtDec := removeAmtDec.Quo(powerReductionDec)
+	disputeAmt := disputeAmtDec.TruncateInt()
+	err = k.tokensToDispute(ctx, stakingtypes.NotBondedPoolName, disputeAmt)
 	if err != nil {
 		return math.Uint{}, err
 	}
@@ -286,7 +307,10 @@ func (k Keeper) deductFromdelegation(ctx context.Context, delAddr sdk.AccAddress
 	tokensFromShare := math.NewUint(currentTokens.BigInt().Uint64() * 1e6) // normalize to match with the normalized delTokens
 	shares := del.Shares
 	if tokensFromShare.GTE(delTokens) {
-		shares, err = validator.SharesFromTokens(math.Int(delTokens.QuoUint64(1e6)))
+		delTokensDec := k.LegacyDecFromMathUint(delTokens)
+		powerReductionDec := math.LegacyNewDecFromInt(layertypes.PowerReduction)
+		tokensAmtDec := delTokensDec.Quo(powerReductionDec)
+		shares, err = validator.SharesFromTokens(tokensAmtDec.TruncateInt())
 		if err != nil {
 			return math.Uint{}, err
 		}


### PR DESCRIPTION
- used legacy decimal for division and then truncated decimals
- added retries for token-bridge daemon eth rpc connection
- added reset function to blobstream contract for re-use on testnet