### PR TITLE
Fix/Issue-41-escrow

### DIFF
--- a/x/reporter/keeper/withdraw.go
+++ b/x/reporter/keeper/withdraw.go
@@ -194,7 +194,7 @@ func (k Keeper) EscrowReporterStake(ctx context.Context, reporterAddr sdk.AccAdd
 		delAddr := sdk.AccAddress(del.DelegatorAddress)
 		valAddr := sdk.ValAddress(del.ValidatorAddress)
 
-		remaining, err := k.undelegate(ctx, delAddr, valAddr, delegatorShare.ToLegacyDec())
+		remaining, err := k.undelegate(ctx, delAddr, valAddr, delegatorShare.ToLegacyDec(), false)
 		if err != nil {
 			return err
 		}
@@ -213,7 +213,7 @@ func (k Keeper) EscrowReporterStake(ctx context.Context, reporterAddr sdk.AccAdd
 			if err != nil {
 				return err
 			}
-			_, err = k.undelegate(ctx, delAddr, dstVAl, math.LegacyNewDecFromInt(remaining))
+			_, err = k.undelegate(ctx, delAddr, dstVAl, math.LegacyNewDecFromInt(remaining), true)
 			if err != nil {
 				return err
 			}
@@ -348,7 +348,7 @@ func (k Keeper) tokensToDispute(ctx context.Context, fromPool string, amount mat
 // undelegate a selector's tokens that are part of a dispute.
 // first attempt to get the tokens from known validator and if not found then chase after the tokens that were either redelegated to another validator
 // or are being unbonded
-func (k Keeper) undelegate(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, delTokens math.LegacyDec) (math.Int, error) {
+func (k Keeper) undelegate(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, delTokens math.LegacyDec, isRedelegating bool) (math.Int, error) {
 	remainingFromdel, err := k.deductFromdelegation(ctx, delAddr, valAddr, delTokens)
 	if err != nil {
 		return math.Int{}, err
@@ -359,15 +359,18 @@ func (k Keeper) undelegate(ctx context.Context, delAddr sdk.AccAddress, valAddr 
 		return math.ZeroInt(), nil
 	}
 
-	remainingUnbonding, err := k.deductUnbondingDelegation(ctx, delAddr, valAddr, remainingFromdel.TruncateInt())
-	if err != nil {
-		if errors.Is(err, stakingtypes.ErrNoUnbondingDelegation) {
-			return remainingFromdel.TruncateInt(), nil
+	remainingUnbonding := math.ZeroInt()
+	if !isRedelegating {
+		remainingUnbonding, err = k.deductUnbondingDelegation(ctx, delAddr, valAddr, remainingFromdel.TruncateInt())
+		if err != nil {
+			if errors.Is(err, stakingtypes.ErrNoUnbondingDelegation) {
+				return remainingFromdel.TruncateInt(), nil
+			}
+			return math.Int{}, err
 		}
-		return math.Int{}, err
-	}
-	if remainingUnbonding.IsZero() {
-		return math.ZeroInt(), nil
+		if remainingUnbonding.IsZero() {
+			return math.ZeroInt(), nil
+		}
 	}
 	return remainingUnbonding, nil
 }


### PR DESCRIPTION
re implemented changes to withdraw.go to avoid dealing with a bunch of merge conflicts for a 1 file changed. And then edited an e2e test to make a reporter redelegate their tokens after reporting and before a dispute is proposed to ensure that we are able to escrow them in the dispute module still