### PR TITLE
fix: Bug/Daemon-bridge-tx-continous-retry

### DIFF
--- a/daemons/reporter/client/broadcast_message.go
+++ b/daemons/reporter/client/broadcast_message.go
@@ -105,6 +105,8 @@ func (c *Client) HandleBridgeDepositTxInChannel(ctx context.Context, data TxChan
 		if data.NumRetries == 0 {
 			// Don't mark as reported if all retries failed
 			c.logger.Error(fmt.Sprintf("failed to submit deposit after all allotted attempts attempts: %v", err))
+			// Remove oldest deposit report from cache
+			c.TokenDepositsCache.RemoveOldestReport()
 			return
 		}
 

--- a/daemons/reporter/client/broadcast_message.go
+++ b/daemons/reporter/client/broadcast_message.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/tellor-io/layer/lib/metrics"
@@ -127,14 +126,10 @@ func (c *Client) HandleBridgeDepositTxInChannel(ctx context.Context, data TxChan
 
 	// Check transaction success
 	if resp.TxResult.Code != 0 {
-		if strings.Contains(resp.TxResult.Log, "reporter has already submitted a report for this query") {
-			c.logger.Info("Reporter has already submitted for this query. Removing from deposits cache")
-		} else {
-			c.logger.Error("deposit report transaction failed",
-				"code", resp.TxResult.Code,
-				"queryId", queryId)
-			return
-		}
+		c.logger.Error("deposit report transaction failed",
+			"code", resp.TxResult.Code,
+			"queryId", queryId,
+			"log", resp.TxResult.Log)
 	}
 
 	// Remove oldest deposit report from cache

--- a/daemons/reporter/client/tx_handler.go
+++ b/daemons/reporter/client/tx_handler.go
@@ -62,7 +62,7 @@ func (c *Client) WaitForTx(ctx context.Context, hash string) (*cmttypes.ResultTx
 					return nil, fmt.Errorf("waiting for next block: err: %w", err)
 				}
 				waitedBlockCount++
-				if waitedBlockCount == 2 {
+				if waitedBlockCount == 3 {
 					return nil, fmt.Errorf("waited for next block and transaction is still not found")
 				}
 				continue

--- a/daemons/reporter/client/tx_handler.go
+++ b/daemons/reporter/client/tx_handler.go
@@ -100,7 +100,7 @@ func (c *Client) Status(ctx context.Context) (*cmttypes.ResultStatus, error) {
 }
 
 func (c *Client) WaitForBlockHeight(ctx context.Context, h int64) error {
-	ticker := time.NewTicker(time.Millisecond * 500)
+	ticker := time.NewTicker(time.Millisecond * 250)
 	defer ticker.Stop()
 
 	for {

--- a/daemons/reporter/client/tx_handler.go
+++ b/daemons/reporter/client/tx_handler.go
@@ -57,14 +57,14 @@ func (c *Client) WaitForTx(ctx context.Context, hash string) (*cmttypes.ResultTx
 		resp, err := c.cosmosCtx.Client.Tx(ctx, bz, false)
 		if err != nil {
 			if strings.Contains(err.Error(), "not found") {
+				if waitedBlockCount == 2 {
+					return nil, fmt.Errorf("waited for next block and transaction is still not found")
+				}
 				err := c.WaitForNextBlock(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("waiting for next block: err: %w", err)
 				}
 				waitedBlockCount++
-				if waitedBlockCount == 3 {
-					return nil, fmt.Errorf("waited for next block and transaction is still not found")
-				}
 				continue
 			}
 			return nil, fmt.Errorf("fetching tx '%s'; err: %w", hash, err)


### PR DESCRIPTION
## Description
Made it so that if a bridge deposit report errors out it will only be retried if it is a sequence error. Changed WaitForTx to wait for a number of blocks instead of a set amount of time

## Related Issue

Fixes #
Bridge deposits that made it through pre check but failed due to conditions in the code were not being removed from the deposits cache and were being retried over and over again. Now if it errors due to an error like that it doesn't retry it at all and removes it from the deposit cache

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [ ] Chain Changes (please describe):
- [ x ] Daemon Changes
- [ ] Tests
- [ ] Added Getter

## Testing
ran a chain to make sure the daemon was still functioning properly and reporting with these new changes

## Checklist
<!-- Mark completed items with an "x" -->
- [ x ] Code follows project style guidelines
- [ x ] I have added appropriate comments to my code
- [ x ] I have updated the documentation accordingly
- [ x ] I have added tests that prove my fix or feature works
- [ x ] go test ./... is passing locally
- [ x ] make e2e is passing locally