### PR TITLE
fix: prevent attestations for flagged reports

### DIFF
--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -854,6 +854,10 @@ func (k Keeper) CreateSnapshot(ctx context.Context, queryId []byte, timestamp ti
 		k.Logger(ctx).Info("Error getting aggregate report by timestamp", "error", err)
 		return err
 	}
+	// check whether report is flagged as disputed. If so, do not create a snapshot.
+	if isExternalRequest && aggReport.Flagged {
+		return errors.New("report is flagged as dispute evidence")
+	}
 	// get the current validator checkpoint
 	validatorCheckpoint, err := k.GetValidatorCheckpointFromStorage(ctx)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Added check for flagged aggregate when requesting new attestations. If flagged, request tx fails

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [x] Chain Changes (please describe): Updated request-attestations tx. No state changes
- [ ] Daemon Changes
- [x] Tests
- [ ] Added Getter

## Testing
<!-- Describe the tests you've performed or added to verify your changes -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] Code follows project style guidelines
- [x] I have added appropriate comments to my code
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix or feature works
- [x] go test ./... is passing locally
- [x] make e2e is passing locally