### PR TITLE
fix: get-validator-set-index-by-timestamp cli

### DIFF
--- a/x/bridge/autocli.go
+++ b/x/bridge/autocli.go
@@ -95,6 +95,12 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Query last withdrawal id",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{},
 				},
+				{
+					RpcMethod:      "GetValidatorSetIndexByTimestamp",
+					Use:            "get-validator-set-index-by-timestamp [timestamp]",
+					Short:          "Query validator set index by timestamp",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "timestamp"}},
+				},
 
 				// this line is used by ignite scaffolding # autocli/query
 			},


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
This cli query wasn't in the autocli file. Added in this PR

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [ ] Chain Changes (please describe):
- [ ] Daemon Changes
- [ ] Tests
- [ ] Added Getter

## Testing
<!-- Describe the tests you've performed or added to verify your changes -->

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] Code follows project style guidelines
- [ ] I have added appropriate comments to my code
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix or feature works
- [ ] go test ./... is passing locally
- [ ] make e2e is passing locally