### PR TITLE
fix: Populate EVMToOperatorAddressMap for existing validators 

### DIFF
--- a/app/upgrades/v5.1.0/upgrade.go
+++ b/app/upgrades/v5.1.0/upgrade.go
@@ -13,9 +13,10 @@ import (
 /*
 	Upgrade to v5.1.0 will include:
 		- test upgrade handler for upgrade testing
+		- migration to populate EVMToOperatorAddressMap for existing validators
 
 	Migrations:
-		- None
+		- Bridge module migration from v3 to v4 includes EVMToOperatorAddressMap population and ValidatorCheckpointParams migration
 */
 
 func CreateUpgradeHandler(

--- a/x/bridge/migrations/v4/store.go
+++ b/x/bridge/migrations/v4/store.go
@@ -2,15 +2,18 @@ package v4
 
 import (
 	"context"
+	"encoding/hex"
 
 	"github.com/gogo/protobuf/proto"
 	bridgetypes "github.com/tellor-io/layer/x/bridge/types"
 
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // ValidatorCheckpointParamsLegacy represents the old ValidatorCheckpointParams struct without BlockHeight
@@ -29,12 +32,29 @@ func (m *ValidatorCheckpointParamsLegacy) String() string {
 }
 func (*ValidatorCheckpointParamsLegacy) ProtoMessage() {}
 
-// MigrateStore migrates the ValidatorCheckpointParams from the legacy format to the new format
-// by adding the BlockHeight field with a default value of 0
+// MigrateStore migrates the bridge module from v3 to v4:
+// 1. Migrates ValidatorCheckpointParams from the legacy format to the new format by adding the BlockHeight field
+// 2. Populates EVMToOperatorAddressMap from existing OperatorToEVMAddressMap entries for slashing functionality
 func MigrateStore(ctx context.Context, storeService store.KVStoreService, cdc codec.BinaryCodec) error {
 	store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
 
-	// Migrate ValidatorCheckpointParams
+	// migrate ValidatorCheckpointParams (existing migration)
+	err := migrateValidatorCheckpointParams(store, cdc)
+	if err != nil {
+		return err
+	}
+
+	// migrate EVMToOperatorAddressMap (new migration)
+	err = migrateEVMToOperatorAddressMap(store, cdc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// migrateValidatorCheckpointParams migrates ValidatorCheckpointParams from legacy format to new format
+func migrateValidatorCheckpointParams(store storetypes.KVStore, cdc codec.BinaryCodec) error {
 	checkpointStore := prefix.NewStore(store, bridgetypes.ValidatorCheckpointParamsMapKey)
 	iter := checkpointStore.Iterator(nil, nil)
 	defer iter.Close()
@@ -60,6 +80,59 @@ func MigrateStore(ctx context.Context, storeService store.KVStoreService, cdc co
 		}
 
 		checkpointStore.Set(iter.Key(), newData)
+	}
+
+	return nil
+}
+
+// migrateEVMToOperatorAddressMap populates EVMToOperatorAddressMap from existing OperatorToEVMAddressMap entries
+func migrateEVMToOperatorAddressMap(store storetypes.KVStore, cdc codec.BinaryCodec) error {
+	// get the operator to EVM address map store
+	operatorToEVMStore := prefix.NewStore(store, bridgetypes.OperatorToEVMAddressMapKey)
+	operatorIter := operatorToEVMStore.Iterator(nil, nil)
+	defer operatorIter.Close()
+
+	// get the EVM to operator address map store for writing
+	evmToOperatorStore := prefix.NewStore(store, bridgetypes.EVMToOperatorAddressMapKey)
+
+	for ; operatorIter.Valid(); operatorIter.Next() {
+		// decode the operator address from the key
+		operatorAddr := string(operatorIter.Key())
+
+		// decode the EVM address from the value
+		var evmAddr bridgetypes.EVMAddress
+		if err := cdc.Unmarshal(operatorIter.Value(), &evmAddr); err != nil {
+			// log error but continue migration for other entries
+			continue
+		}
+
+		// convert EVM address bytes to hex string (this is how it's stored as key in EVMToOperatorAddressMap)
+		evmAddressString := hex.EncodeToString(evmAddr.EVMAddress)
+
+		// check if reverse mapping already exists
+		evmKey := []byte(evmAddressString)
+		if evmToOperatorStore.Has(evmKey) {
+			// mapping already exists, skip
+			continue
+		}
+
+		// create the operator address type
+		sdkValAddr, err := sdk.ValAddressFromBech32(operatorAddr)
+		if err != nil {
+			continue
+		}
+
+		operatorAddrType := bridgetypes.OperatorAddress{
+			OperatorAddress: sdkValAddr,
+		}
+
+		operatorData, err := cdc.Marshal(&operatorAddrType)
+		if err != nil {
+			continue
+		}
+
+		// set the reverse mapping
+		evmToOperatorStore.Set(evmKey, operatorData)
 	}
 
 	return nil

--- a/x/bridge/migrations/v4/store_test.go
+++ b/x/bridge/migrations/v4/store_test.go
@@ -7,6 +7,7 @@ import (
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cosmosdb "github.com/cosmos/cosmos-db"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"github.com/tellor-io/layer/x/bridge/keeper"
@@ -23,6 +24,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -127,16 +130,175 @@ func createLegacyValidatorCheckpointParams(t *testing.T, ctx context.Context, st
 	store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
 	checkpointStore := prefix.NewStore(store, bridgetypes.ValidatorCheckpointParamsMapKey)
 
-	for i, data := range legacyData {
+	for _, data := range legacyData {
 		// use timestamp as key (uint64 -> []byte)
 		key := sdk.Uint64ToBigEndian(data.Timestamp)
 		value, err := cdc.Marshal(&data)
 		require.NoError(t, err)
 		checkpointStore.Set(key, value)
-		t.Logf("Stored legacy checkpoint %d with timestamp %d", i, data.Timestamp)
 	}
 
 	return legacyData
+}
+
+// TestEVMAddressMigration tests the migration of OperatorToEVMAddressMap to EVMToOperatorAddressMap
+func TestEVMAddressMigration(t *testing.T) {
+	ctx, storeService, cdc, _ := setupTest(t)
+
+	// Generate valid validator addresses for testing
+	pk1 := secp256k1.GenPrivKey()
+	pk2 := secp256k1.GenPrivKey()
+	pk3 := secp256k1.GenPrivKey()
+
+	addr1 := sdk.AccAddress(pk1.PubKey().Address())
+	addr2 := sdk.AccAddress(pk2.PubKey().Address())
+	addr3 := sdk.AccAddress(pk3.PubKey().Address())
+
+	valAddr1 := sdk.ValAddress(addr1)
+	valAddr2 := sdk.ValAddress(addr2)
+	valAddr3 := sdk.ValAddress(addr3)
+
+	evmHex1 := "1234567890abcdef1234567890abcdef12345678"
+	evmHex2 := "abcdef1234567890abcdef1234567890abcdef12"
+	evmHex3 := "fedcba0987654321fedcba0987654321fedcba09"
+
+	// Test data: operator addresses and corresponding EVM addresses
+	testData := []struct {
+		operatorAddr string
+		evmAddrHex   string
+		evmAddrBytes []byte
+	}{
+		{
+			operatorAddr: valAddr1.String(),
+			evmAddrHex:   evmHex1,
+			evmAddrBytes: common.FromHex(evmHex1),
+		},
+		{
+			operatorAddr: valAddr2.String(),
+			evmAddrHex:   evmHex2,
+			evmAddrBytes: common.FromHex(evmHex2),
+		},
+		{
+			operatorAddr: valAddr3.String(),
+			evmAddrHex:   evmHex3,
+			evmAddrBytes: common.FromHex(evmHex3),
+		},
+	}
+
+	// Create and store test data in OperatorToEVMAddressMap
+	store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	operatorToEVMStore := prefix.NewStore(store, bridgetypes.OperatorToEVMAddressMapKey)
+
+	for _, data := range testData {
+		evmAddr := bridgetypes.EVMAddress{
+			EVMAddress: data.evmAddrBytes,
+		}
+		value, err := cdc.Marshal(&evmAddr)
+		require.NoError(t, err)
+
+		operatorToEVMStore.Set([]byte(data.operatorAddr), value)
+	}
+
+	// Run migration
+	err := v4.MigrateStore(ctx, storeService, cdc)
+	require.NoError(t, err, "Migration should succeed")
+
+	// Verify EVMToOperatorAddressMap was populated correctly
+	evmToOperatorStore := prefix.NewStore(store, bridgetypes.EVMToOperatorAddressMapKey)
+
+	for i, data := range testData {
+		// Key should be the hex string (without 0x prefix)
+		evmKey := []byte(data.evmAddrHex)
+
+		// Verify the reverse mapping exists
+		require.True(t, evmToOperatorStore.Has(evmKey),
+			"Reverse mapping should exist for EVM address %s", data.evmAddrHex)
+
+		// Get and verify the value
+		value := evmToOperatorStore.Get(evmKey)
+		require.NotNil(t, value, "Value should not be nil for EVM address %s", data.evmAddrHex)
+
+		var operatorAddr bridgetypes.OperatorAddress
+		err := cdc.Unmarshal(value, &operatorAddr)
+		require.NoError(t, err, "Should unmarshal operator address")
+
+		// Verify the operator address matches
+		expectedValAddr, err := sdk.ValAddressFromBech32(data.operatorAddr)
+		require.NoError(t, err)
+		require.Equal(t, expectedValAddr.Bytes(), operatorAddr.OperatorAddress,
+			"Operator address should match for entry %d", i)
+	}
+}
+
+// TestEVMAddressMigrationWithKeeper tests the migration through the keeper interface
+func TestEVMAddressMigrationWithKeeper(t *testing.T) {
+	ctx, storeService, cdc, bk := setupTest(t)
+
+	// Generate valid validator address
+	pk := secp256k1.GenPrivKey()
+	addr := sdk.AccAddress(pk.PubKey().Address())
+	valAddr := sdk.ValAddress(addr)
+
+	operatorAddr := valAddr.String()
+	evmAddrBytes := common.FromHex("0x1234567890abcdef1234567890abcdef12345678")
+	evmAddrHex := "1234567890abcdef1234567890abcdef12345678"
+
+	// Create initial mapping using the store directly (simulating pre-migration state)
+	store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	operatorToEVMStore := prefix.NewStore(store, bridgetypes.OperatorToEVMAddressMapKey)
+
+	evmAddr := bridgetypes.EVMAddress{EVMAddress: evmAddrBytes}
+	value, err := cdc.Marshal(&evmAddr)
+	require.NoError(t, err)
+	operatorToEVMStore.Set([]byte(operatorAddr), value)
+
+	// Run migration through keeper
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	m := keeper.NewMigrator(bk)
+	err = m.Migrate3to4(sdkCtx)
+	require.NoError(t, err)
+
+	// Test that the keeper can now access the reverse mapping
+	// verify original mapping still exists
+	storedEVMAddr, err := bk.OperatorToEVMAddressMap.Get(ctx, operatorAddr)
+	require.NoError(t, err)
+	require.Equal(t, evmAddrBytes, storedEVMAddr.EVMAddress)
+
+	// Verify reverse mapping exists and is accessible via raw store access
+	// (since the keeper doesn't have a direct method for EVMToOperatorAddressMap access in the test)
+	evmToOperatorStore := prefix.NewStore(store, bridgetypes.EVMToOperatorAddressMapKey)
+	evmKey := []byte(evmAddrHex)
+	require.True(t, evmToOperatorStore.Has(evmKey))
+
+	value = evmToOperatorStore.Get(evmKey)
+	var operatorAddrResult bridgetypes.OperatorAddress
+	err = cdc.Unmarshal(value, &operatorAddrResult)
+	require.NoError(t, err)
+
+	expectedValAddr, err := sdk.ValAddressFromBech32(operatorAddr)
+	require.NoError(t, err)
+	require.Equal(t, expectedValAddr.Bytes(), operatorAddrResult.OperatorAddress)
+
+	storedOperatorAddr, err := bk.EVMToOperatorAddressMap.Get(ctx, evmAddrHex)
+	require.NoError(t, err)
+	require.Equal(t, operatorAddr, sdk.ValAddress(storedOperatorAddr.OperatorAddress).String())
+}
+
+// TestEVMAddressMigrationEmpty tests migration with empty stores
+func TestEVMAddressMigrationEmpty(t *testing.T) {
+	ctx, storeService, cdc, _ := setupTest(t)
+
+	// Run migration on empty store
+	err := v4.MigrateStore(ctx, storeService, cdc)
+	require.NoError(t, err, "Migration should succeed even with empty OperatorToEVMAddressMap")
+
+	// Verify EVMToOperatorAddressMap is still empty
+	store := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	evmToOperatorStore := prefix.NewStore(store, bridgetypes.EVMToOperatorAddressMapKey)
+
+	iter := evmToOperatorStore.Iterator(nil, nil)
+	defer iter.Close()
+	require.False(t, iter.Valid(), "EVMToOperatorAddressMap should be empty")
 }
 
 func TestMigrateStore(t *testing.T) {
@@ -173,8 +335,6 @@ func TestMigrateStore(t *testing.T) {
 
 		// verify new field was set to 0 (as specified in the migration)
 		require.Equal(t, uint64(0), newParams.BlockHeight, "BlockHeight should be set to 0 for existing entries")
-
-		t.Logf("Successfully migrated checkpoint with timestamp %d", data.Timestamp)
 	}
 }
 

--- a/x/bridge/migrations/v4/store_test.go
+++ b/x/bridge/migrations/v4/store_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
We added the EVMToOperatorAddressMap used for attestation slashing. This map is set when validators register their EVM addresses. This PR adds a migration for setting existing validators' EVMToOperatorAddressMap.

Note: I labelled this PR as a state change, even though it's not. It migrates a state change from a previous PR: https://github.com/tellor-io/layer/pull/722

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] State Changes (please describe)": migrates a state change from PR #722
- [X] Chain Changes (please describe): updates bridge module v4 migration
- [ ] Daemon Changes
- [X] Tests
- [ ] Added Getter

## Testing
<!-- Describe the tests you've performed or added to verify your changes -->

## Checklist
<!-- Mark completed items with an "x" -->
- [X] Code follows project style guidelines
- [X] I have added appropriate comments to my code
- [ ] I have updated the documentation accordingly
- [X] I have added tests that prove my fix or feature works
- [X] go test ./... is passing locally
- [X] make e2e is passing locally