### PR TITLE
Fix/dispute executes too early

### DIFF
--- a/tests/integration/dispute_keeper_test.go
+++ b/tests/integration/dispute_keeper_test.go
@@ -120,20 +120,60 @@ func (s *IntegrationTestSuite) TestVotingOnDispute() {
 	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{
 		Voter: teamAddr.String(),
 		Id:    1,
-		Vote:  types.VoteEnum_VOTE_SUPPORT,
+		Vote:  types.VoteEnum_VOTE_INVALID,
 	})
 	s.NoError(err)
 	vtr, err := s.Setup.Disputekeeper.Voter.Get(s.Setup.Ctx, collections.Join(uint64(1), teamAddr.Bytes()))
 	s.NoError(err)
-	s.Equal(types.VoteEnum_VOTE_SUPPORT, vtr.Vote)
+	s.Equal(types.VoteEnum_VOTE_INVALID, vtr.Vote)
 	v, err := s.Setup.Disputekeeper.Votes.Get(s.Setup.Ctx, 1)
 	s.NoError(err)
 	s.Equal(v.VoteResult, types.VoteResult_NO_TALLY)
+	expectedTally := types.StakeholderVoteCounts{
+		Team: types.VoteCounts{
+			Invalid: 1,
+		},
+	}
+	t, err := s.Setup.Disputekeeper.VoteCountsByGroup.Get(s.Setup.Ctx, uint64(1))
+	s.NoError(err)
+	s.Equal(expectedTally, t)
+	s.Equal(t.Reporters.Invalid, uint64(0))
+	s.Equal(t.Users.Invalid, uint64(0))
 	iter, err := s.Setup.Disputekeeper.Voter.Indexes.VotersById.MatchExact(s.Setup.Ctx, uint64(1))
 	s.NoError(err)
 	voters, err := iter.PrimaryKeys()
 	s.NoError(err)
 	s.Equal(voters[0].K2(), teamAddr.Bytes())
+
+	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{
+		Voter: teamAddr.String(),
+		Id:    1,
+		Vote:  types.VoteEnum_VOTE_AGAINST,
+	})
+	s.NoError(err)
+	vtr, err = s.Setup.Disputekeeper.Voter.Get(s.Setup.Ctx, collections.Join(uint64(1), teamAddr.Bytes()))
+	s.NoError(err)
+	s.Equal(types.VoteEnum_VOTE_AGAINST, vtr.Vote)
+	v, err = s.Setup.Disputekeeper.Votes.Get(s.Setup.Ctx, 1)
+	s.NoError(err)
+	s.Equal(v.VoteResult, types.VoteResult_NO_TALLY)
+	expectedTally = types.StakeholderVoteCounts{
+		Team: types.VoteCounts{
+			Against: 1,
+			Invalid: 0,
+		},
+	}
+	t, err = s.Setup.Disputekeeper.VoteCountsByGroup.Get(s.Setup.Ctx, uint64(1))
+	s.NoError(err)
+	s.Equal(expectedTally, t)
+	s.Equal(t.Reporters.Invalid, uint64(0))
+	s.Equal(t.Users.Invalid, uint64(0))
+	iter, err = s.Setup.Disputekeeper.Voter.Indexes.VotersById.MatchExact(s.Setup.Ctx, uint64(1))
+	s.NoError(err)
+	voters, err = iter.PrimaryKeys()
+	s.NoError(err)
+	s.Equal(voters[0].K2(), teamAddr.Bytes())
+
 }
 
 func (s *IntegrationTestSuite) TestProposeDisputeFromBond() {

--- a/tests/integration/dispute_test.go
+++ b/tests/integration/dispute_test.go
@@ -1684,6 +1684,17 @@ func (s *IntegrationTestSuite) TestDisputes2() {
 	msgVote = disputetypes.MsgVote{
 		Voter: teamAddr.String(),
 		Id:    dispute.DisputeId,
+		Vote:  disputetypes.VoteEnum_VOTE_AGAINST,
+	}
+	voteResponse, err = msgServerDispute.Vote(s.Setup.Ctx, &msgVote)
+	require.NoError(err)
+	require.NotNil(voteResponse)
+
+	// vote from team again with different vote
+	require.NoError(err)
+	msgVote = disputetypes.MsgVote{
+		Voter: teamAddr.String(),
+		Id:    dispute.DisputeId,
 		Vote:  disputetypes.VoteEnum_VOTE_SUPPORT,
 	}
 	voteResponse, err = msgServerDispute.Vote(s.Setup.Ctx, &msgVote)

--- a/x/dispute/keeper/msg_server_vote.go
+++ b/x/dispute/keeper/msg_server_vote.go
@@ -38,31 +38,32 @@ func (k msgServer) Vote(goCtx context.Context, msg *types.MsgVote) (*types.MsgVo
 	if err != nil {
 		return nil, err
 	}
-	var oldVote types.Voter
+	var oldVote *types.Voter
 	// Check if voter has already voted
 	if voted {
-		oldVote, err = k.Voter.Get(ctx, collections.Join(msg.Id, voterAcc.Bytes()))
+		voteData, err := k.Voter.Get(ctx, collections.Join(msg.Id, voterAcc.Bytes()))
 		if err != nil {
 			return nil, err
 		}
-		if oldVote.Vote == msg.Vote {
+		if voteData.Vote == msg.Vote {
 			return nil, types.ErrVoterHasAlreadyVoted
 		}
+		oldVote = &voteData
 	}
 
 	// Assert again voting hasn't ended
 	if vote.VoteEnd.Before(ctx.BlockTime()) {
 		return nil, types.ErrVotingPeriodEnded
 	}
-	teampower, err := k.SetTeamVote(ctx, msg.Id, voterAcc, msg.Vote, &oldVote)
+	teampower, err := k.SetTeamVote(ctx, msg.Id, voterAcc, msg.Vote, oldVote)
 	if err != nil {
 		return nil, err
 	}
-	upower, err := k.Keeper.SetVoterTips(ctx, msg.Id, voterAcc, dispute.BlockNumber, msg.Vote, &oldVote)
+	upower, err := k.Keeper.SetVoterTips(ctx, msg.Id, voterAcc, dispute.BlockNumber, msg.Vote, oldVote)
 	if err != nil {
 		return nil, err
 	}
-	repP, err := k.SetVoterReporterStake(ctx, msg.Id, voterAcc, dispute.BlockNumber, msg.Vote, &oldVote)
+	repP, err := k.SetVoterReporterStake(ctx, msg.Id, voterAcc, dispute.BlockNumber, msg.Vote, oldVote)
 	if err != nil {
 		return nil, err
 	}

--- a/x/dispute/keeper/msg_server_vote_test.go
+++ b/x/dispute/keeper/msg_server_vote_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"encoding/hex"
-	"fmt"
 	"testing"
 	"time"
 
@@ -67,17 +66,19 @@ func (s *KeeperTestSuite) TestVote() {
 	// vote from team
 	teamAddr, err := s.disputeKeeper.GetTeamAddress(s.ctx)
 	s.NoError(err)
+
 	_, err = s.disputeKeeper.SetTeamVote(s.ctx, uint64(1), teamAddr, types.VoteEnum_VOTE_SUPPORT, nil)
 	s.NoError(err)
 
-	err = s.disputeKeeper.TallyVote(s.ctx, uint64(1))
+	// check on voting tally
+	_, err = s.disputeKeeper.VoteCountsByGroup.Get(s.ctx, uint64(1))
 	s.NoError(err)
 
-	// check on voting tally
-	data, err := s.disputeKeeper.VoteCountsByGroup.Get(s.ctx, uint64(1))
-	s.NoError(err)
-	fmt.Println(data)
 	// vote calls tally, enough ppl have voted to reach quorum
+	vote, err = s.disputeKeeper.Votes.Get(s.ctx, 1)
+	s.NoError(err)
+	s.NotNil(vote)
+
 	s.Equal(vote.VoteResult, types.VoteResult_SUPPORT)
 	s.Equal(vote.Id, uint64(1))
 }

--- a/x/dispute/keeper/msg_server_vote_test.go
+++ b/x/dispute/keeper/msg_server_vote_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"testing"
 	"time"
 
@@ -66,12 +67,16 @@ func (s *KeeperTestSuite) TestVote() {
 	// vote from team
 	teamAddr, err := s.disputeKeeper.GetTeamAddress(s.ctx)
 	s.NoError(err)
-	_, err = s.disputeKeeper.SetTeamVote(s.ctx, uint64(1), teamAddr, types.VoteEnum_VOTE_SUPPORT)
+	_, err = s.disputeKeeper.SetTeamVote(s.ctx, uint64(1), teamAddr, types.VoteEnum_VOTE_SUPPORT, nil)
+	s.NoError(err)
+
+	err = s.disputeKeeper.TallyVote(s.ctx, uint64(1))
 	s.NoError(err)
 
 	// check on voting tally
-	_, err = s.disputeKeeper.VoteCountsByGroup.Get(s.ctx, uint64(1))
+	data, err := s.disputeKeeper.VoteCountsByGroup.Get(s.ctx, uint64(1))
 	s.NoError(err)
+	fmt.Println(data)
 	// vote calls tally, enough ppl have voted to reach quorum
 	s.Equal(vote.VoteResult, types.VoteResult_SUPPORT)
 	s.Equal(vote.Id, uint64(1))

--- a/x/dispute/keeper/tally.go
+++ b/x/dispute/keeper/tally.go
@@ -76,9 +76,6 @@ func (k Keeper) TallyVote(ctx context.Context, id uint64) error {
 	if err != nil {
 		return err
 	}
-	if vote.VoteEnd.Before(sdk.UnwrapSDKContext(ctx).BlockTime()) {
-		dispute.Open = false
-	}
 
 	voteCounts, err := k.VoteCountsByGroup.Get(ctx, id)
 	if err != nil {

--- a/x/dispute/keeper/tally.go
+++ b/x/dispute/keeper/tally.go
@@ -192,7 +192,7 @@ func (k Keeper) TallyVote(ctx context.Context, id uint64) error {
 		}
 	}
 
-	if totalRatio.GTE(math.LegacyNewDec(51).Mul(layertypes.PowerReduction.ToLegacyDec()).Quo(totalPossiblePower)) && !dispute.Open {
+	if totalRatio.GTE(math.LegacyNewDec(51).Mul(layertypes.PowerReduction.ToLegacyDec())) && !dispute.Open {
 		return k.markDisputeForExecution(ctx, id, scaledSupport, scaledAgainst, scaledInvalid, dispute, vote)
 	}
 

--- a/x/dispute/keeper/tally_test.go
+++ b/x/dispute/keeper/tally_test.go
@@ -175,7 +175,7 @@ func (s *KeeperTestSuite) TestTallyVote() {
 					Team: types.VoteCounts{Support: 0, Against: 0, Invalid: 0},
 				}))
 				// set team vote
-				require.NoError(k.Voter.Set(ctx, collections.Join(disputeId, teamAddr.Bytes()), types.Voter{Vote: types.VoteEnum_VOTE_SUPPORT, VoterPower: math.NewInt(25000000)}))
+				require.NoError(k.Voter.Set(ctx, collections.Join(disputeId, teamAddr.Bytes()), types.Voter{Vote: types.VoteEnum_VOTE_SUPPORT, VoterPower: math.NewInt(33333333)}))
 				// mock for GetTotalSupply
 				bk.On("GetSupply", ctx, layertypes.BondDenom).Return(sdk.Coin{Denom: layertypes.BondDenom, Amount: math.NewInt(250 * 1e6)}, nil)
 			},
@@ -211,18 +211,27 @@ func (s *KeeperTestSuite) TestTallyVote() {
 			disputeId: uint64(2),
 			setup: func() {
 				disputeId := uint64(2)
+				require.NoError(k.Disputes.Set(ctx, disputeId, types.Dispute{
+					HashId:    []byte("hashId4"),
+					DisputeId: disputeId,
+					Open:      true,
+				}))
+				require.NoError(k.BlockInfo.Set(ctx, []byte("hashId4"), types.BlockInfo{
+					TotalReporterPower: math.NewInt(60 * 1e6),
+					TotalUserTips:      math.NewInt(60 * 1e6),
+				}))
 				require.NoError(k.VoteCountsByGroup.Set(ctx, disputeId, types.StakeholderVoteCounts{
 					Team:      types.VoteCounts{Support: 33333333, Against: 0, Invalid: 0},
-					Users:     types.VoteCounts{Support: 50000000, Against: 0, Invalid: 0},
-					Reporters: types.VoteCounts{Support: 50000000, Against: 0, Invalid: 0},
+					Users:     types.VoteCounts{Support: 0, Against: 20 * 1e6, Invalid: 0},
+					Reporters: types.VoteCounts{Support: 0, Against: 20 * 1e6, Invalid: 0},
 				}))
 			},
 			teardown:      func() {},
 			expectedError: nil,
 			expectedVotes: types.StakeholderVoteCounts{
 				Team:      types.VoteCounts{Support: 33333333, Against: 0, Invalid: 0},
-				Reporters: types.VoteCounts{Support: 50000000, Against: 0, Invalid: 0},
-				Users:     types.VoteCounts{Support: 50000000, Against: 0, Invalid: 0},
+				Reporters: types.VoteCounts{Support: 0, Against: 20 * 1e6, Invalid: 0},
+				Users:     types.VoteCounts{Support: 0, Against: 20 * 1e6, Invalid: 0},
 			},
 		},
 		{

--- a/x/dispute/keeper/tally_test.go
+++ b/x/dispute/keeper/tally_test.go
@@ -226,7 +226,7 @@ func (s *KeeperTestSuite) TestTallyVote() {
 			},
 		},
 		{
-			name:      "everybody votes, quorum reached",
+			name:      "everybody votes, quorum reached and dispute is closed",
 			disputeId: uint64(4),
 			setup: func() {
 				disputeId := uint64(4)
@@ -261,6 +261,49 @@ func (s *KeeperTestSuite) TestTallyVote() {
 			},
 			teardown:      func() {},
 			expectedError: nil,
+			expectedVotes: types.StakeholderVoteCounts{
+				Team:      types.VoteCounts{Support: 0, Against: 0, Invalid: 33333333},
+				Users:     types.VoteCounts{Support: 22500000, Against: 22500000, Invalid: 15000000},
+				Reporters: types.VoteCounts{Support: 27500000, Against: 22500000, Invalid: 10000000},
+			},
+		},
+		{
+			name:      "51% ratio is reached but for a split vote and dispute is still in voting period",
+			disputeId: uint64(6),
+			setup: func() {
+				disputeId := uint64(6)
+				// get team address
+				teamAddr, err := k.GetTeamAddress(ctx)
+				require.NoError(err)
+				// set dispute voting status
+				require.NoError(k.Votes.Set(ctx, disputeId, types.Vote{
+					Id:         disputeId,
+					VoteResult: types.VoteResult_NO_TALLY,
+				}))
+				// set dispute info
+				require.NoError(k.Disputes.Set(ctx, disputeId, types.Dispute{
+					HashId:    []byte("hashId4"),
+					DisputeId: disputeId,
+					Open:      true,
+				}))
+				// set block info
+				require.NoError(k.BlockInfo.Set(ctx, []byte("hashId4"), types.BlockInfo{
+					TotalReporterPower: math.NewInt(60 * 1e6),
+					TotalUserTips:      math.NewInt(60 * 1e6),
+				}))
+				// set vote counts by group
+				require.NoError(k.VoteCountsByGroup.Set(ctx, disputeId, types.StakeholderVoteCounts{
+					Team:      types.VoteCounts{Support: 0, Against: 0, Invalid: 33333333},
+					Users:     types.VoteCounts{Support: 22500000, Against: 22500000, Invalid: 15000000},
+					Reporters: types.VoteCounts{Support: 27500000, Against: 22500000, Invalid: 10000000},
+				}))
+				// set team vote
+				require.NoError(k.Voter.Set(ctx, collections.Join(disputeId, teamAddr.Bytes()), types.Voter{Vote: types.VoteEnum_VOTE_INVALID, VoterPower: math.NewInt(25000000)}))
+				// mock for GetTotalSupply
+				bk.On("GetSupply", ctx, layertypes.BondDenom).Return(sdk.Coin{Denom: layertypes.BondDenom, Amount: math.NewInt(60 * 1e6)}, nil)
+			},
+			teardown:      func() {},
+			expectedError: errors.New(types.ErrNoQuorumStillVoting.Error()),
 			expectedVotes: types.StakeholderVoteCounts{
 				Team:      types.VoteCounts{Support: 0, Against: 0, Invalid: 33333333},
 				Users:     types.VoteCounts{Support: 22500000, Against: 22500000, Invalid: 15000000},

--- a/x/dispute/keeper/vote.go
+++ b/x/dispute/keeper/vote.go
@@ -46,7 +46,6 @@ func (k Keeper) SetTeamVote(ctx context.Context, id uint64, voter sdk.AccAddress
 	}
 
 	if bytes.Equal(voter, teamAddr) {
-
 		voteCounts, err := k.VoteCountsByGroup.Get(ctx, id)
 		if err != nil {
 			if !errors.Is(err, collections.ErrNotFound) {
@@ -69,19 +68,19 @@ func (k Keeper) SetTeamVote(ctx context.Context, id uint64, voter sdk.AccAddress
 					voteCounts.Team.Support = 0
 				case types.VoteEnum_VOTE_AGAINST:
 					voteCounts.Team.Against = 0
-				default:
+				case types.VoteEnum_VOTE_INVALID:
 					voteCounts.Team.Invalid = 0
 				}
 			}
-			err = k.VoteCountsByGroup.Set(ctx, id, voteCounts)
-			if err != nil {
-				return math.Int{}, err
-			}
-			// return doesnt get used in dispute calculations
-			// just gets set in Voter collection as the team's voter.VoterPower which doesnt matter for tally calculations
-			power := math.NewInt(100000000).Quo(math.NewInt(3))
-			return power, nil
 		}
+		err = k.VoteCountsByGroup.Set(ctx, id, voteCounts)
+		if err != nil {
+			return math.Int{}, err
+		}
+		// return doesnt get used in dispute calculations
+		// just gets set in Voter collection as the team's voter.VoterPower which doesnt matter for tally calculations
+		power := math.NewInt(100000000).Quo(math.NewInt(3))
+		return power, nil
 	}
 	return math.ZeroInt(), nil
 }
@@ -124,7 +123,7 @@ func (k Keeper) SetVoterTips(ctx context.Context, id uint64, voter sdk.AccAddres
 					voteCounts.Users.Support -= tips.Uint64()
 				case types.VoteEnum_VOTE_AGAINST:
 					voteCounts.Users.Against -= tips.Uint64()
-				default:
+				case types.VoteEnum_VOTE_INVALID:
 					voteCounts.Users.Invalid -= tips.Uint64()
 				}
 			}
@@ -241,7 +240,7 @@ func (k Keeper) AddReporterVoteCount(ctx context.Context, id, amount uint64, cho
 				voteCounts.Reporters.Support -= amount
 			case types.VoteEnum_VOTE_AGAINST:
 				voteCounts.Reporters.Against -= amount
-			default:
+			case types.VoteEnum_VOTE_INVALID:
 				voteCounts.Reporters.Invalid -= amount
 			}
 		}

--- a/x/dispute/keeper/vote_test.go
+++ b/x/dispute/keeper/vote_test.go
@@ -66,7 +66,7 @@ func (s *KeeperTestSuite) TestTeamVote_SetTeamVote() {
 	// team votes SUPPORT
 	teamAddr, err := k.GetTeamAddress(ctx)
 	require.NoError(err)
-	teamVote, err := k.SetTeamVote(ctx, disputeId, teamAddr, types.VoteEnum_VOTE_SUPPORT)
+	teamVote, err := k.SetTeamVote(ctx, disputeId, teamAddr, types.VoteEnum_VOTE_SUPPORT, nil)
 	require.NoError(err)
 	require.Equal(teamVote, math.NewInt(100000000).Quo(math.NewInt(3)))
 	// check on vote
@@ -77,7 +77,7 @@ func (s *KeeperTestSuite) TestTeamVote_SetTeamVote() {
 	require.NoError(err)
 
 	// vote from bad account, expect return 0
-	badTeamVote, err := k.SetTeamVote(ctx, disputeId, sample.AccAddressBytes(), types.VoteEnum_VOTE_SUPPORT)
+	badTeamVote, err := k.SetTeamVote(ctx, disputeId, sample.AccAddressBytes(), types.VoteEnum_VOTE_SUPPORT, nil)
 	require.NoError(err)
 	require.Equal(badTeamVote, math.NewInt(0))
 
@@ -120,7 +120,7 @@ func (s *KeeperTestSuite) TestSetVoterTips() {
 	// user1 has tipped 100 trb, votes support
 	user1 := sample.AccAddressBytes()
 	s.oracleKeeper.On("GetTipsAtBlockForTipper", ctx, blockNum, user1).Return(math.NewInt(100), nil).Once()
-	tips, err := k.SetVoterTips(ctx, disputeId, user1, uint64(10), types.VoteEnum_VOTE_SUPPORT)
+	tips, err := k.SetVoterTips(ctx, disputeId, user1, uint64(10), types.VoteEnum_VOTE_SUPPORT, nil)
 	require.NoError(err)
 	require.Equal(tips, math.NewInt(100))
 	// check on vote
@@ -133,7 +133,7 @@ func (s *KeeperTestSuite) TestSetVoterTips() {
 	// user2 has tipped 200 trb, votes against
 	user2 := sample.AccAddressBytes()
 	s.oracleKeeper.On("GetTipsAtBlockForTipper", ctx, blockNum, user2).Return(math.NewInt(200), nil).Once()
-	tips, err = k.SetVoterTips(ctx, disputeId, user2, uint64(10), types.VoteEnum_VOTE_AGAINST)
+	tips, err = k.SetVoterTips(ctx, disputeId, user2, uint64(10), types.VoteEnum_VOTE_AGAINST, nil)
 	require.NoError(err)
 	require.Equal(tips, math.NewInt(200))
 	// check on vote
@@ -146,13 +146,13 @@ func (s *KeeperTestSuite) TestSetVoterTips() {
 	// nonUser, expect return 0
 	nonUser := sample.AccAddressBytes()
 	s.oracleKeeper.On("GetTipsAtBlockForTipper", ctx, blockNum, nonUser).Return(math.NewInt(0), nil).Once()
-	tips, err = k.SetVoterTips(ctx, disputeId, nonUser, blockNum, types.VoteEnum_VOTE_SUPPORT)
+	tips, err = k.SetVoterTips(ctx, disputeId, nonUser, blockNum, types.VoteEnum_VOTE_SUPPORT, nil)
 	require.NoError(err)
 	require.Equal(tips, math.NewInt(0))
 
 	// non collections not found error on GetUserTotalTips, expect return math.Int{}, err
 	s.oracleKeeper.On("GetTipsAtBlockForTipper", ctx, blockNum, nonUser).Return(math.NewInt(0), errors.New("error")).Once()
-	tips, err = k.SetVoterTips(ctx, disputeId, nonUser, blockNum, types.VoteEnum_VOTE_SUPPORT)
+	tips, err = k.SetVoterTips(ctx, disputeId, nonUser, blockNum, types.VoteEnum_VOTE_SUPPORT, nil)
 	require.Error(err)
 	require.Equal(tips, math.Int{})
 }
@@ -358,7 +358,7 @@ func (s *KeeperTestSuite) TestSetVoterReportStake() {
 		if tc.setup != nil {
 			s.Run(tc.name, tc.setup)
 		}
-		tokensVoted, err := k.SetVoterReporterStake(ctx, disputeId, tc.voter, blockNum, types.VoteEnum_VOTE_SUPPORT)
+		tokensVoted, err := k.SetVoterReporterStake(ctx, disputeId, tc.voter, blockNum, types.VoteEnum_VOTE_SUPPORT, nil)
 		if tc.expectedError {
 			require.Error(err)
 		} else {
@@ -510,7 +510,7 @@ func (s *KeeperTestSuite) TestAddAndSubtractReporterVoteCount() {
 	disputeId := uint64(1)
 
 	// add 100 support
-	err := k.AddReporterVoteCount(ctx, disputeId, 100, types.VoteEnum_VOTE_SUPPORT)
+	err := k.AddReporterVoteCount(ctx, disputeId, 100, types.VoteEnum_VOTE_SUPPORT, nil)
 	require.NoError(err)
 	votesByGroup, err := k.VoteCountsByGroup.Get(ctx, disputeId)
 	require.NoError(err)
@@ -522,7 +522,7 @@ func (s *KeeperTestSuite) TestAddAndSubtractReporterVoteCount() {
 	require.NoError(err)
 	require.Equal(votesByGroup.Reporters.Support, uint64(0))
 
-	err = k.AddReporterVoteCount(ctx, disputeId, 100, types.VoteEnum_VOTE_AGAINST)
+	err = k.AddReporterVoteCount(ctx, disputeId, 100, types.VoteEnum_VOTE_AGAINST, nil)
 	require.NoError(err)
 	votesByGroup, err = k.VoteCountsByGroup.Get(ctx, disputeId)
 	require.NoError(err)
@@ -534,7 +534,7 @@ func (s *KeeperTestSuite) TestAddAndSubtractReporterVoteCount() {
 	require.NoError(err)
 	require.Equal(votesByGroup.Reporters.Against, uint64(0))
 
-	err = k.AddReporterVoteCount(ctx, disputeId, 100, types.VoteEnum_VOTE_INVALID)
+	err = k.AddReporterVoteCount(ctx, disputeId, 100, types.VoteEnum_VOTE_INVALID, nil)
 	require.NoError(err)
 	votesByGroup, err = k.VoteCountsByGroup.Get(ctx, disputeId)
 	require.NoError(err)


### PR DESCRIPTION
## Description
Disputes were Executing too early during voting period whenever the total ratio of votes reached quorum. Also the reporter and user ratios used to update the scaled tallies of votes was being computed using the total power of votes received not the total power retrieved from the BlockInfo.

Disputes will now only execute before the voting period has ended if 51% of the scaled voting power all agree before voting has ended. 

Feat: If a dispute is still in its voting phase and you want to change your vote you can now just submit another vote tx with your new vote and it will overwrite your previous vote

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ x ] Bug fix
- [ x ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [ x ] Chain Changes (please describe): changed the vote tx and how disputes are tallied/when they are executed
- [ ] Daemon Changes
- [ ] Tests
- [ ] Added Getter

## Testing
added test cases for people changing their vote and the new tally to ensure that disputes were in the expected state 

## Checklist
<!-- Mark completed items with an "x" -->
- [ x ] Code follows project style guidelines
- [ x ] I have added appropriate comments to my code
- [ x ] I have updated the documentation accordingly
- [ x ] I have added tests that prove my fix or feature works
- [ x ] go test ./... is passing locally
- [ x ] make e2e is passing locally