### PR TITLE
Chore: Add timestamp to new aggregate report event

### DIFF
--- a/x/oracle/keeper/aggregate.go
+++ b/x/oracle/keeper/aggregate.go
@@ -162,6 +162,7 @@ func (k Keeper) SetAggregate(ctx context.Context, report *types.Aggregate, query
 			sdk.NewAttribute("aggregate_power", strconv.FormatUint(report.AggregatePower, 10)),
 			sdk.NewAttribute("micro_report_height", fmt.Sprintf("%d", report.MicroHeight)),
 			sdk.NewAttribute("micro_report_type", queryType),
+			sdk.NewAttribute("timestamp", fmt.Sprintf("%d", currentTimestamp)),
 		),
 	})
 	telemetry.SetGaugeWithLabels([]string{"reporter_power_in_aggregates"}, float32(report.AggregatePower), []metrics.Label{{Name: "chain_id", Value: sdkCtx.ChainID()}, {Name: "query_id", Value: hex.EncodeToString(report.QueryId)}})


### PR DESCRIPTION
added timestamp to aggregate_report event to make it easier to query and see what reporters missed out on an aggregate when we get an alert for a non consensus aggregate

## Description
<!-- Provide a brief summary of the changes in this PR -->

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [ x ] Chain Changes (please describe): added an attribute to an event
- [ ] Daemon Changes
- [ ] Tests
- [ ] Added Getter

## Testing

## Checklist
<!-- Mark completed items with an "x" -->
- [ x ] Code follows project style guidelines
- [ x ] I have added appropriate comments to my code
- [ x ] I have updated the documentation accordingly
- [ x ] I have added tests that prove my fix or feature works
- [ x ] go test ./... is passing locally
- [ x ] make e2e is passing locally