### PR TITLE
Fix mint keeper logic

### DIFF
--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -86,6 +86,15 @@ func (k Keeper) MintCoins(ctx context.Context, newCoins sdk.Coins) error {
 		return nil
 	}
 	k.Logger(ctx).Info("minting tbr", "coins", newCoins)
+	// emit event with amount and destination
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	sdkCtx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			"mint_coins",
+			sdk.NewAttribute("amount", newCoins.String()),
+			sdk.NewAttribute("destination", types.ModuleName),
+		),
+	})
 	return k.bankKeeper.MintCoins(ctx, types.ModuleName, newCoins)
 }
 
@@ -101,11 +110,6 @@ func (k Keeper) SendInflationaryRewards(ctx context.Context, coins sdk.Coins) er
 	}
 	quarter := coinsAmt.QuoRaw(4)
 	threequarters := coinsAmt.Sub(quarter)
-
-	// Emit event for normal inflationary rewards distribution
-	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	totalRewardCoins := sdk.NewCoins(sdk.NewCoin(layer.BondDenom, threequarters.Add(quarter)))
-
 	outputs := []banktypes.Output{
 		{
 			Address: authtypes.NewModuleAddressOrBech32Address(types.TimeBasedRewards).String(),
@@ -122,6 +126,9 @@ func (k Keeper) SendInflationaryRewards(ctx context.Context, coins sdk.Coins) er
 	if err != nil {
 		return err
 	}
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+	totalRewardCoins := sdk.NewCoins(sdk.NewCoin(layer.BondDenom, coinsAmt))
 	sdkCtx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(
 			"inflationary_rewards_distributed",
@@ -187,9 +194,8 @@ func (k Keeper) SendExtraRewards(ctx context.Context) error {
 	quarter := rewardAmountInt.QuoRaw(4)
 	threequarters := rewardAmountInt.Sub(quarter)
 
-	// Emit event for extra rewards distribution
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	totalRewardCoins := sdk.NewCoins(sdk.NewCoin(rewardParams.BondDenom, threequarters.Add(quarter)))
+	totalRewardCoins := sdk.NewCoins(sdk.NewCoin(rewardParams.BondDenom, rewardAmountInt))
 
 	outputs := []banktypes.Output{
 		{


### PR DESCRIPTION
## Description
Updates x/mint/keeper/keeper.go with the right implementation from release/v6.x.

This difference was discovered while trying to merge the release branch with main. The release/v6.x branch had the correct keeper logic, so bringing it to main.

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [ ] Chain Changes (please describe):
- [ ] Daemon Changes
- [ ] Tests
- [ ] Added Getter

## Testing
<!-- Describe the tests you've performed or added to verify your changes -->

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] Code follows project style guidelines
- [ ] I have added appropriate comments to my code
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix or feature works
- [ ] go test ./... is passing locally
- [ ] make e2e is passing locally