### PR TITLE
Fix/dispute multiround review findings

### DIFF
--- a/adr/adr1011 - dispute round fees.md
+++ b/adr/adr1011 - dispute round fees.md
@@ -16,7 +16,7 @@ This ADR is about what the fee is for each round and what happens to it.
 
 Round 1's fee is refundable. You pay the dispute fee, which is the same as the slash amount. If the dispute resolves support you get your fee back minus a small burn and you also get the reporter's slashed tokens. If it resolves invalid you just get your fee back minus the burn. If it resolves against you the reporter gets your fee. So the round 1 fee comes back to you unless you lose the dispute.
 
-Rounds 2 and up are different. The fee you pay to start another round is not refundable to anyone. It is a burn. The whole fee gets consumed, half of it is actually burned and half goes to the voters of the dispute. The only thing that is ever refundable is the round 1 fee.
+Rounds 2 and up are different. The fee you pay to start another round is not refundable to anyone. It is a burn. The whole fee gets consumed, half of it is actually burned and half goes to the voters of the dispute (if no users or reporters voted in any round, the voter half is burned as well). The only thing that is ever refundable is the round 1 fee.
 
 The fee for each extra round starts at 5% of the slash amount and doubles each round. So round 2 is 10% of the slash, round 3 is 20%, round 4 is 40%, round 5 is 80%, capped at 100%. It gets expensive fast on purpose.
 
@@ -34,11 +34,10 @@ The round 1 fee stays separate from all of this. It is the part that is actually
 
 The fee schedule for reference, with s as the slash amount (5% is s/20):
 
-- Round 1: pay s. This is the refundable fee. 5% goes to the burn pool, 95% is refundable.
+- Round 1: pay s. This is the refundable fee. 5% is consumed (half burned, half reserved as the voter reward; all of it burned if no users or reporters voted), 95% is refundable.
 - Round 2: pay s/10 (10% of s). Fully consumed.
 - Round 3: pay s/5 (20%). Fully consumed.
 - Round 4: pay 2s/5 (40%). Fully consumed.
 - Round 5: pay 4s/5 (80%). Fully consumed.
 
 Disputes are capped at 5 rounds.
-

--- a/tests/integration/dispute_multiround_support_test.go
+++ b/tests/integration/dispute_multiround_support_test.go
@@ -501,3 +501,84 @@ func (s *IntegrationTestSuite) TestClaimableDisputeRewardsUsesFirstRoundFeePayer
 	s.NoError(err)
 	s.Equal(expectedClaimable, resp.ClaimableAmount.FeeRefundAmount, "final-round query should report the round-1 payer's fee refund plus reporter bond reward")
 }
+
+// TestClaimableDisputeRewardsIncludesPreviousRoundOnlyVoter: ClaimReward pays voters
+// from any round by scanning PrevDisputeIds, so the query must not require a Voter
+// record under the final round id before reporting the reward.
+func (s *IntegrationTestSuite) TestClaimableDisputeRewardsIncludesPreviousRoundOnlyVoter() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	_, report, disputeFee := s.setupDisputedReporter(100)
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	previousRoundOnlyVoter := s.fundedDisputer()
+	s.seedTipper(previousRoundOnlyVoter, report)
+
+	// round 1 is voted on (and left unresolved) by the tipper, not the team
+	roundOnePayer := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOnePayer, false, previousRoundOnlyVoter)
+
+	// the tipper does not vote in round 2; the team resolves it
+	disputer2 := s.fundedDisputer()
+	s.proposeRound(msgServer, disputer2, report, disputeFee, false)
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_SUPPORT)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
+
+	expectedReward, err := s.Setup.Disputekeeper.CalculateReward(s.Setup.Ctx, previousRoundOnlyVoter, 2)
+	s.NoError(err)
+	s.True(expectedReward.IsPositive(), "the previous-round-only voter should have a real claimable reward")
+
+	queryServer := keeper.NewQuerier(s.Setup.Disputekeeper)
+	resp, err := queryServer.ClaimableDisputeRewards(s.Setup.Ctx, &types.QueryClaimableDisputeRewardsRequest{
+		DisputeId: 2,
+		Address:   previousRoundOnlyVoter.String(),
+	})
+	s.NoError(err)
+	s.Equal(expectedReward, resp.ClaimableAmount.RewardAmount, "the query should report rewards for voters who only participated in previous rounds")
+}
+
+// TestWorstCaseClaimableDisputeRewardsShowsCombinedPreviousRoundClaims: one address is
+// both the round-1 fee payer and a previous-round-only voter, and the user queries the
+// final dispute id. The query must report both the fee refund and the voter reward, and
+// both amounts must actually be withdrawable through the transaction paths.
+func (s *IntegrationTestSuite) TestWorstCaseClaimableDisputeRewardsShowsCombinedPreviousRoundClaims() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	_, report, disputeFee := s.setupDisputedReporter(100)
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	// the claimant pays the round-1 fee and is the only round-1 voter
+	claimant := s.fundedDisputer()
+	s.seedTipper(claimant, report)
+	s.startNoQuorumRound1(msgServer, report, disputeFee, claimant, false, claimant)
+
+	roundTwoPayer := s.fundedDisputer()
+	s.proposeRound(msgServer, roundTwoPayer, report, disputeFee, false)
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_SUPPORT)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
+
+	finalDispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
+	s.NoError(err)
+	expectedReward, err := s.Setup.Disputekeeper.CalculateReward(s.Setup.Ctx, claimant, 2)
+	s.NoError(err)
+	s.True(expectedReward.IsPositive(), "the claimant should have a real previous-round-only voter reward")
+	expectedRefund, _ := keeper.CalculateRefundAmount(finalDispute.SlashAmount, finalDispute.SlashAmount)
+	expectedFeeRefund := expectedRefund.Add(finalDispute.SlashAmount)
+
+	queryServer := keeper.NewQuerier(s.Setup.Disputekeeper)
+	resp, err := queryServer.ClaimableDisputeRewards(s.Setup.Ctx, &types.QueryClaimableDisputeRewardsRequest{
+		DisputeId: 2,
+		Address:   claimant.String(),
+	})
+	s.NoError(err)
+	s.Equal(expectedFeeRefund, resp.ClaimableAmount.FeeRefundAmount, "final-id query must show the round-1 fee refund plus reporter bond reward")
+	s.Equal(expectedReward, resp.ClaimableAmount.RewardAmount, "final-id query must show the previous-round-only voter reward")
+
+	// the amounts the query reports are really withdrawable through the tx paths
+	_, err = msgServer.WithdrawFeeRefund(s.Setup.Ctx, &types.MsgWithdrawFeeRefund{Id: 2, PayerAddress: claimant.String(), CallerAddress: claimant.String()})
+	s.NoError(err)
+	_, err = msgServer.ClaimReward(s.Setup.Ctx, &types.MsgClaimReward{CallerAddress: claimant.String(), DisputeId: 2})
+	s.NoError(err)
+}

--- a/tests/integration/dispute_multiround_support_test.go
+++ b/tests/integration/dispute_multiround_support_test.go
@@ -470,6 +470,47 @@ func (s *IntegrationTestSuite) TestWorstCaseTeamOnlyMaxRoundDoesNotStrandEscalat
 	s.True(modBalance.Amount.IsZero(), "escalation fees must be fully consumed rather than stranded in the dispute module")
 }
 
+// TestMultiRoundFinalRoundNoVotesStillRewardsPreviousRoundVoters: if the final round
+// expires with no votes, previous-round user/reporter voters are still claim-eligible,
+// so the voter half of the consumed fee pool must be reserved and claimable.
+func (s *IntegrationTestSuite) TestMultiRoundFinalRoundNoVotesStillRewardsPreviousRoundVoters() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	_, report, disputeFee := s.setupDisputedReporter(100)
+
+	previousRoundVoter := s.fundedDisputer()
+	s.seedTipper(previousRoundVoter, report)
+
+	roundOnePayer := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOnePayer, false, previousRoundVoter)
+
+	roundTwoPayer := s.fundedDisputer()
+	s.proposeRound(msgServer, roundTwoPayer, report, disputeFee, false)
+
+	hasFinalRoundVoteCounts, err := s.Setup.Disputekeeper.VoteCountsByGroup.Has(s.Setup.Ctx, 2)
+	s.NoError(err)
+	s.False(hasFinalRoundVoteCounts, "final round must have no vote counts for this regression")
+
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(s.Setup.Ctx.BlockTime().Add(keeper.THREE_DAYS + 1))
+	s.NoError(s.Setup.Disputekeeper.TallyVote(s.Setup.Ctx, 2))
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
+
+	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
+	s.NoError(err)
+	s.Equal(types.Resolved, dispute.DisputeStatus)
+	s.Equal(dispute.BurnAmount.QuoRaw(2), dispute.VoterReward, "previous-round voters should keep the voter reward claimable")
+
+	expectedReward, err := s.Setup.Disputekeeper.CalculateReward(s.Setup.Ctx, previousRoundVoter, 2)
+	s.Require().NoError(err)
+	s.True(expectedReward.IsPositive(), "previous-round voter should have a claimable reward")
+
+	balBefore := s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, previousRoundVoter, s.Setup.Denom)
+	_, err = msgServer.ClaimReward(s.Setup.Ctx, &types.MsgClaimReward{CallerAddress: previousRoundVoter.String(), DisputeId: 2})
+	s.NoError(err)
+	balAfter := s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, previousRoundVoter, s.Setup.Denom)
+	s.Equal(expectedReward, balAfter.Amount.Sub(balBefore.Amount))
+}
+
 // TestClaimableDisputeRewardsUsesFirstRoundFeePayerForFinalRound: fee payer records
 // live under the first-round dispute id, but wallets query the final resolved round id.
 // The query must resolve the round-1 payer the same way WithdrawFeeRefund does.

--- a/tests/integration/dispute_multiround_support_test.go
+++ b/tests/integration/dispute_multiround_support_test.go
@@ -1,5 +1,9 @@
 package integration_test
 
+// Integration tests for multi-round dispute fee accounting. Round-1 fees are the only
+// refundable fees; later (escalation) round fees are fully consumed as burn and voter
+// rewards.
+
 import (
 	"encoding/hex"
 	"fmt"
@@ -17,56 +21,114 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
-// setupDisputedReporter registers a validator-reporter and stores a disputable report.
-func (s *IntegrationTestSuite) setupDisputedReporter(power uint64) (sdk.AccAddress, oracletypes.MicroReport, math.Int) {
-	repAccs, _, _ := s.createValidatorAccs([]uint64{power})
-	reporterAcc := repAccs[0]
-	s.NoError(s.Setup.Reporterkeeper.Reporters.Set(s.Setup.Ctx, reporterAcc, reportertypes.NewReporter(reportertypes.DefaultMinCommissionRate, math.OneInt(), "reporter_moniker")))
-	s.NoError(s.Setup.Reporterkeeper.Selectors.Set(s.Setup.Ctx, reporterAcc, reportertypes.NewSelection(reporterAcc, 1)))
+// setupDisputedReporterWithBondPayers registers a validator-reporter for each power and
+// stores a disputable report for the first one. The extra reporters have stake of their
+// own, so they can pay dispute fees from bond without disputing their own report.
+func (s *IntegrationTestSuite) setupDisputedReporterWithBondPayers(powers ...uint64) ([]sdk.AccAddress, oracletypes.MicroReport, math.Int) {
+	repAccs, _, _ := s.createValidatorAccs(powers)
+	for i, reporter := range repAccs {
+		s.NoError(s.Setup.Reporterkeeper.Reporters.Set(s.Setup.Ctx, reporter, reportertypes.NewReporter(reportertypes.DefaultMinCommissionRate, math.OneInt(), fmt.Sprintf("reporter_moniker_%d", i))))
+		s.NoError(s.Setup.Reporterkeeper.Selectors.Set(s.Setup.Ctx, reporter, reportertypes.NewSelection(reporter, 1)))
+	}
 
+	disputedReporter := repAccs[0]
 	qId, _ := hex.DecodeString("83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992")
-	stake, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, reporterAcc, qId)
+	stake, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, disputedReporter, qId)
 	s.NoError(err)
 	report := oracletypes.MicroReport{
-		Reporter:    reporterAcc.String(),
+		Reporter:    disputedReporter.String(),
 		Power:       stake.Quo(sdk.DefaultPowerReduction).Uint64(),
 		QueryId:     qId,
 		Value:       "000000000000000000000000000000000000000000000058528649cf80ee0000",
 		Timestamp:   time.Now().Add(-1 * 12 * time.Hour),
 		BlockNumber: uint64(s.Setup.Ctx.BlockHeight()),
 	}
-	s.NoError(s.Setup.Oraclekeeper.Reports.Set(s.Setup.Ctx, collections.Join3(report.QueryId, reporterAcc.Bytes(), report.MetaId), report))
+	s.NoError(s.Setup.Oraclekeeper.Reports.Set(s.Setup.Ctx, collections.Join3(report.QueryId, disputedReporter.Bytes(), report.MetaId), report))
 	fee, err := s.Setup.Disputekeeper.GetDisputeFee(s.Setup.Ctx, report, types.Warning)
 	s.NoError(err)
-	return reporterAcc, report, fee
+	return repAccs, report, fee
 }
 
-// startNoQuorumRound1 proposes a dispute (round 1, fully funded by disputer1), gives it only the
-// team vote so it ends Unresolved, and returns once a new round can be added.
-func (s *IntegrationTestSuite) startNoQuorumRound1(msgServer types.MsgServer, report oracletypes.MicroReport, disputeFee math.Int, disputer1, teamAddr sdk.AccAddress) {
-	disputeMsg := types.MsgProposeDispute{
-		Creator:          disputer1.String(),
+// setupDisputedReporter registers a single validator-reporter and stores a disputable report.
+func (s *IntegrationTestSuite) setupDisputedReporter(power uint64) (sdk.AccAddress, oracletypes.MicroReport, math.Int) {
+	repAccs, report, fee := s.setupDisputedReporterWithBondPayers(power)
+	return repAccs[0], report, fee
+}
+
+// fundedDisputer returns a fresh account with enough free tokens to pay dispute fees.
+func (s *IntegrationTestSuite) fundedDisputer() sdk.AccAddress {
+	addr := s.newKeysWithTokens()
+	s.Setup.MintTokens(addr, math.NewInt(100_000_000))
+	return addr
+}
+
+// seedTipper credits addr with all tips at the report's block so the address carries
+// user voting power for disputes over that report.
+func (s *IntegrationTestSuite) seedTipper(addr sdk.AccAddress, report oracletypes.MicroReport) {
+	s.NoError(s.Setup.Oraclekeeper.TipperTotal.Set(s.Setup.Ctx, collections.Join(addr.Bytes(), report.BlockNumber), math.NewInt(100)))
+	s.NoError(s.Setup.Oraclekeeper.TotalTips.Set(s.Setup.Ctx, report.BlockNumber, math.NewInt(100)))
+}
+
+// proposeRound submits a fully funded warning-category dispute proposal; while the
+// dispute is open and unresolved this opens the next escalation round.
+func (s *IntegrationTestSuite) proposeRound(msgServer types.MsgServer, creator sdk.AccAddress, report oracletypes.MicroReport, fee math.Int, payFromBond bool) {
+	_, err := msgServer.ProposeDispute(s.Setup.Ctx, &types.MsgProposeDispute{
+		Creator:          creator.String(),
 		DisputedReporter: report.Reporter,
 		ReportMetaId:     report.MetaId,
 		ReportQueryId:    hex.EncodeToString(report.QueryId),
-		Fee:              sdk.NewCoin(s.Setup.Denom, disputeFee),
+		Fee:              sdk.NewCoin(s.Setup.Denom, fee),
 		DisputeCategory:  types.Warning,
-	}
-	_, err := msgServer.ProposeDispute(s.Setup.Ctx, &disputeMsg)
+		PayFromBond:      payFromBond,
+	})
 	s.NoError(err)
+}
+
+// markRoundUnresolved gives the round a single INVALID vote that cannot reach quorum,
+// waits out the voting period, and tallies, leaving the round Unresolved so the next
+// escalation round can be opened.
+func (s *IntegrationTestSuite) markRoundUnresolved(msgServer types.MsgServer, disputeId uint64, voter sdk.AccAddress) {
+	_, err := msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: voter.String(), Id: disputeId, Vote: types.VoteEnum_VOTE_INVALID})
+	s.NoError(err)
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(s.Setup.Ctx.BlockTime().Add(keeper.TWO_DAYS + 1))
+	s.NoError(s.Setup.Disputekeeper.TallyVote(s.Setup.Ctx, disputeId))
+	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, disputeId)
+	s.NoError(err)
+	s.Equal(types.Unresolved, dispute.DisputeStatus, "round must be unresolved so the next escalation round can be opened")
+}
+
+// startNoQuorumRound1 proposes a dispute fully funded by payer (optionally from bond),
+// seeds the dispute's block info, and leaves round 1 Unresolved via a single no-quorum
+// vote by voter.
+func (s *IntegrationTestSuite) startNoQuorumRound1(msgServer types.MsgServer, report oracletypes.MicroReport, disputeFee math.Int, payer sdk.AccAddress, payFromBond bool, voter sdk.AccAddress) {
+	s.proposeRound(msgServer, payer, report, disputeFee, payFromBond)
 	d1, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 1)
 	s.NoError(err)
 	s.NoError(s.Setup.Disputekeeper.BlockInfo.Set(s.Setup.Ctx, d1.HashId, types.BlockInfo{TotalReporterPower: math.NewInt(int64(report.Power)).Mul(sdk.DefaultPowerReduction), TotalUserTips: math.NewInt(100)}))
-	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: teamAddr.String(), Id: 1, Vote: types.VoteEnum_VOTE_INVALID})
-	s.NoError(err)
-	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(s.Setup.Ctx.BlockTime().Add(keeper.TWO_DAYS + 1))
-	s.NoError(s.Setup.Disputekeeper.TallyVote(s.Setup.Ctx, 1))
+	s.markRoundUnresolved(msgServer, 1, voter)
 }
 
-// TestMultiRoundSupportRefundsRoundOneStakeOnly on a multi-round SUPPORT,
-// the round-1 fee payer is refunded their round-1 stake (95%) and receives the full
-// slashed bond, while a later-round fee payer gets nothing. their escalating round fee was a
-// burn and not a refundable stake.
+// voteAndTally casts a single vote on the round, waits out the voting period, and tallies.
+func (s *IntegrationTestSuite) voteAndTally(msgServer types.MsgServer, disputeId uint64, voter sdk.AccAddress, vote types.VoteEnum) {
+	_, err := msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: voter.String(), Id: disputeId, Vote: vote})
+	s.NoError(err)
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(s.Setup.Ctx.BlockTime().Add(keeper.THREE_DAYS + 1))
+	s.NoError(s.Setup.Disputekeeper.TallyVote(s.Setup.Ctx, disputeId))
+}
+
+func feeTrackerContainsDelegator(tracker reportertypes.DelegationsAmounts, delegator sdk.AccAddress) bool {
+	for _, origin := range tracker.TokenOrigins {
+		if sdk.AccAddress(origin.DelegatorAddress).Equals(delegator) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMultiRoundSupportRefundsRoundOneStakeOnly: on a multi-round SUPPORT resolution,
+// the round-1 fee payer is refunded 95% of the round-1 fee and receives the full slashed
+// bond, while a later-round payer gets nothing: escalation-round fees are fully consumed
+// and never refundable.
 func (s *IntegrationTestSuite) TestMultiRoundSupportRefundsRoundOneStakeOnly() {
 	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
 	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
@@ -74,26 +136,13 @@ func (s *IntegrationTestSuite) TestMultiRoundSupportRefundsRoundOneStakeOnly() {
 	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
 	s.NoError(err)
 
-	disputer1 := s.newKeysWithTokens()
-	s.Setup.MintTokens(disputer1, math.NewInt(100_000_000))
-	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, teamAddr)
+	disputer1 := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, false, teamAddr)
 
 	// round 2 funded by a different payer, then resolves SUPPORT
-	disputer2 := s.newKeysWithTokens()
-	s.Setup.MintTokens(disputer2, math.NewInt(100_000_000))
-	_, err = msgServer.ProposeDispute(s.Setup.Ctx, &types.MsgProposeDispute{
-		Creator:          disputer2.String(),
-		DisputedReporter: report.Reporter,
-		ReportMetaId:     report.MetaId,
-		ReportQueryId:    hex.EncodeToString(report.QueryId),
-		Fee:              sdk.NewCoin(s.Setup.Denom, disputeFee),
-		DisputeCategory:  types.Warning,
-	})
-	s.NoError(err)
-	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: teamAddr.String(), Id: 2, Vote: types.VoteEnum_VOTE_SUPPORT})
-	s.NoError(err)
-	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(s.Setup.Ctx.BlockTime().Add(keeper.THREE_DAYS + 1))
-	s.NoError(s.Setup.Disputekeeper.TallyVote(s.Setup.Ctx, 2))
+	disputer2 := s.fundedDisputer()
+	s.proposeRound(msgServer, disputer2, report, disputeFee, false)
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_SUPPORT)
 	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
 
 	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
@@ -101,12 +150,12 @@ func (s *IntegrationTestSuite) TestMultiRoundSupportRefundsRoundOneStakeOnly() {
 	s.Equal(types.Resolved, dispute.DisputeStatus)
 	slashAmount := dispute.SlashAmount
 
-	// the round-2 fee was not added to a refundable stake:
-	// BurnAmount = round-1's 5% (SlashAmount/20) + the entire round-2 fee (SlashAmount/10).
+	// the round-2 fee is consumed in full:
+	// BurnAmount = round-1's 5% (SlashAmount/20) + the entire round-2 fee (SlashAmount/10)
 	roundFee2 := slashAmount.QuoRaw(10)
 	s.Equal(slashAmount.QuoRaw(20).Add(roundFee2), dispute.BurnAmount)
 
-	// round-1 payer: refunded 95% of their round-1 stake + the full slashed bond
+	// round-1 payer: refunded 95% of the round-1 fee + the full slashed bond
 	expRefund, _ := keeper.CalculateRefundAmount(slashAmount, slashAmount)
 	bondedBefore, err := s.Setup.Stakingkeeper.TotalBondedTokens(s.Setup.Ctx)
 	s.NoError(err)
@@ -116,91 +165,61 @@ func (s *IntegrationTestSuite) TestMultiRoundSupportRefundsRoundOneStakeOnly() {
 	s.Equal(expRefund, s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, disputer1, s.Setup.Denom).Amount.Sub(bal1Before.Amount))
 	bondedAfter, err := s.Setup.Stakingkeeper.TotalBondedTokens(s.Setup.Ctx)
 	s.NoError(err)
-	s.Equal(slashAmount, bondedAfter.Sub(bondedBefore)) // entire slashed bond returned to the round-1 payer
+	s.Equal(slashAmount, bondedAfter.Sub(bondedBefore)) // entire slashed bond restaked to the round-1 payer
 
-	// round-2 payer should not receive round 2 fee back
+	// round-2 payer does not get the round-2 fee back
 	_, err = msgServer.WithdrawFeeRefund(s.Setup.Ctx, &types.MsgWithdrawFeeRefund{Id: 2, PayerAddress: disputer2.String(), CallerAddress: disputer2.String()})
 	s.Error(err)
-
-	fmt.Printf("Slash=%s round1Refund=%s bondToRd1Payer=%s burn=%s\n", slashAmount, expRefund, slashAmount, dispute.BurnAmount)
 }
 
-// TestMultiRoundSupportConservesWithVoterClaim:
-// the round-1 payer claims (fee refund + bond), the round-2 payer gets nothing, and the voters
-// get the voter reward, which should be 2.5% percent of round-1's fee + half of round-2's fee.
-// The dispute module should not have a balance.
+// TestMultiRoundSupportConservesWithVoterClaim: after a multi-round SUPPORT resolution,
+// the round-1 payer claims the fee refund plus the slashed bond, the round-2 payer gets
+// nothing, and the voter claims the voter reward (half of BurnAmount: 2.5% of the
+// round-1 fee plus half of the round-2 fee). All claims together drain the dispute
+// module to ~zero.
 func (s *IntegrationTestSuite) TestMultiRoundSupportConservesWithVoterClaim() {
 	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
 	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
-
-	repAccs, _, _ := s.createValidatorAccs([]uint64{100, 10})
-	reporterAcc := repAccs[0]
-	tipper := repAccs[1]
-	s.NoError(s.Setup.Reporterkeeper.Reporters.Set(s.Setup.Ctx, reporterAcc, reportertypes.NewReporter(reportertypes.DefaultMinCommissionRate, math.OneInt(), "reporter_moniker")))
-	s.NoError(s.Setup.Reporterkeeper.Selectors.Set(s.Setup.Ctx, reporterAcc, reportertypes.NewSelection(reporterAcc, 1)))
-
-	qId, _ := hex.DecodeString("83a7f3d48786ac2667503a61e8c415438ed2922eb86a2906e4ee66d9a2ce4992")
-	stake, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, reporterAcc, qId)
-	s.NoError(err)
-	report := oracletypes.MicroReport{
-		Reporter:    reporterAcc.String(),
-		Power:       stake.Quo(sdk.DefaultPowerReduction).Uint64(),
-		QueryId:     qId,
-		Value:       "000000000000000000000000000000000000000000000058528649cf80ee0000",
-		Timestamp:   time.Now().Add(-1 * 12 * time.Hour),
-		BlockNumber: uint64(s.Setup.Ctx.BlockHeight()),
-	}
-	s.NoError(s.Setup.Oraclekeeper.Reports.Set(s.Setup.Ctx, collections.Join3(report.QueryId, reporterAcc.Bytes(), report.MetaId), report))
-	s.NoError(s.Setup.Oraclekeeper.TipperTotal.Set(s.Setup.Ctx, collections.Join(tipper.Bytes(), report.BlockNumber), math.NewInt(100)))
-	s.NoError(s.Setup.Oraclekeeper.TotalTips.Set(s.Setup.Ctx, report.BlockNumber, math.NewInt(100)))
-
-	disputeFee, err := s.Setup.Disputekeeper.GetDisputeFee(s.Setup.Ctx, report, types.Warning)
-	s.NoError(err)
+	_, report, disputeFee := s.setupDisputedReporter(100)
 	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
 	s.NoError(err)
 
-	disputer1 := s.newKeysWithTokens()
-	s.Setup.MintTokens(disputer1, math.NewInt(100_000_000))
-	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, teamAddr)
+	tipper := s.fundedDisputer()
+	s.seedTipper(tipper, report)
 
-	disputer2 := s.newKeysWithTokens()
-	s.Setup.MintTokens(disputer2, math.NewInt(100_000_000))
-	_, err = msgServer.ProposeDispute(s.Setup.Ctx, &types.MsgProposeDispute{
-		Creator:          disputer2.String(),
-		DisputedReporter: report.Reporter,
-		ReportMetaId:     report.MetaId,
-		ReportQueryId:    hex.EncodeToString(report.QueryId),
-		Fee:              sdk.NewCoin(s.Setup.Denom, disputeFee),
-		DisputeCategory:  types.Warning,
-	})
-	s.NoError(err)
+	disputer1 := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, false, teamAddr)
+
+	disputer2 := s.fundedDisputer()
+	s.proposeRound(msgServer, disputer2, report, disputeFee, false)
 	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: teamAddr.String(), Id: 2, Vote: types.VoteEnum_VOTE_SUPPORT})
 	s.NoError(err)
 	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: tipper.String(), Id: 2, Vote: types.VoteEnum_VOTE_SUPPORT})
 	s.NoError(err)
 
+	// team power plus all user power reach quorum, so the round resolves without
+	// waiting out the voting period
 	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
 	s.NoError(err)
 	s.Equal(types.Resolved, dispute.DisputeStatus)
-	if dispute.PendingExecution {
-		s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
-	}
+	s.True(dispute.PendingExecution)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
 	vote, err := s.Setup.Disputekeeper.Votes.Get(s.Setup.Ctx, 2)
 	s.NoError(err)
 	s.Equal(types.VoteResult_SUPPORT, vote.VoteResult)
 	dispute, err = s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
 	s.NoError(err)
 
-	// the voter reward includes the round-2 fees voter half
+	// the voter reward is half of the consumed pool, which includes the round-2 fee
 	s.Equal(dispute.BurnAmount.QuoRaw(2), dispute.VoterReward)
-	s.True(dispute.VoterReward.GT(dispute.SlashAmount.QuoRaw(40))) // more than round-1's burn alone
+	s.True(dispute.VoterReward.GT(dispute.SlashAmount.QuoRaw(40))) // more than round-1's voter half alone
 
 	disputeModAddr := authtypes.NewModuleAddress(types.ModuleName)
 
 	// round-1 payer claims refund + bond
 	_, err = msgServer.WithdrawFeeRefund(s.Setup.Ctx, &types.MsgWithdrawFeeRefund{Id: 2, PayerAddress: disputer1.String(), CallerAddress: disputer1.String()})
 	s.NoError(err)
-	// round-2 payer is not refunded the fee.
+	// round-2 payer is not refunded the fee
 	_, err = msgServer.WithdrawFeeRefund(s.Setup.Ctx, &types.MsgWithdrawFeeRefund{Id: 2, PayerAddress: disputer2.String(), CallerAddress: disputer2.String()})
 	s.Error(err)
 	// voter claims the voter reward
@@ -208,13 +227,12 @@ func (s *IntegrationTestSuite) TestMultiRoundSupportConservesWithVoterClaim() {
 	s.NoError(err)
 
 	modFinal := s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, disputeModAddr, s.Setup.Denom)
-	fmt.Printf("voterReward=%s | dispute module balance after all claims: %s\n", dispute.VoterReward, modFinal.Amount)
-	s.True(modFinal.Amount.LTE(math.NewInt(1)), "dispute module should net to ~zero, has %s", modFinal.Amount)
+	s.True(modFinal.Amount.LTE(math.NewInt(1)), "dispute module should net to ~zero after all claims, has %s", modFinal.Amount)
 }
 
-// TestMultiRoundAgainstReporterGetsRoundOneStakeOnly:
-// when a multi-round dispute resolves AGAINST, the reporter is awarded their bond back plus 95% of
-// the round-1 fee and not the later-round fees, which were burned. Disputers get nothing.
+// TestMultiRoundAgainstReporterGetsRoundOneStakeOnly: when a multi-round dispute
+// resolves AGAINST, the reporter is awarded their bond back plus 95% of the round-1 fee,
+// while later-round fees stay consumed. Disputers get nothing.
 func (s *IntegrationTestSuite) TestMultiRoundAgainstReporterGetsRoundOneStakeOnly() {
 	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
 	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
@@ -222,26 +240,13 @@ func (s *IntegrationTestSuite) TestMultiRoundAgainstReporterGetsRoundOneStakeOnl
 	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
 	s.NoError(err)
 
-	disputer1 := s.newKeysWithTokens()
-	s.Setup.MintTokens(disputer1, math.NewInt(100_000_000))
-	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, teamAddr)
+	disputer1 := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, false, teamAddr)
 
-	// round 2 funded by a different payer.
-	disputer2 := s.newKeysWithTokens()
-	s.Setup.MintTokens(disputer2, math.NewInt(100_000_000))
-	_, err = msgServer.ProposeDispute(s.Setup.Ctx, &types.MsgProposeDispute{
-		Creator:          disputer2.String(),
-		DisputedReporter: report.Reporter,
-		ReportMetaId:     report.MetaId,
-		ReportQueryId:    hex.EncodeToString(report.QueryId),
-		Fee:              sdk.NewCoin(s.Setup.Denom, disputeFee),
-		DisputeCategory:  types.Warning,
-	})
-	s.NoError(err)
-	_, err = msgServer.Vote(s.Setup.Ctx, &types.MsgVote{Voter: teamAddr.String(), Id: 2, Vote: types.VoteEnum_VOTE_AGAINST})
-	s.NoError(err)
-	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(s.Setup.Ctx.BlockTime().Add(keeper.THREE_DAYS + 1))
-	s.NoError(s.Setup.Disputekeeper.TallyVote(s.Setup.Ctx, 2))
+	// round 2 funded by a different payer
+	disputer2 := s.fundedDisputer()
+	s.proposeRound(msgServer, disputer2, report, disputeFee, false)
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_AGAINST)
 
 	disputeModAddr := authtypes.NewModuleAddress(types.ModuleName)
 	bondedBefore, err := s.Setup.Stakingkeeper.TotalBondedTokens(s.Setup.Ctx)
@@ -257,10 +262,11 @@ func (s *IntegrationTestSuite) TestMultiRoundAgainstReporterGetsRoundOneStakeOnl
 	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
 	s.NoError(err)
 
-	// reporter gets bond back + 95% of the round-1 fee.
+	// reporter gets bond back + 95% of the round-1 fee
 	expectedReporterGain := dispute.SlashAmount.Add(dispute.DisputeFee.Sub(dispute.DisputeFee.QuoRaw(20)))
 	s.Equal(expectedReporterGain, bondedAfter.Sub(bondedBefore))
 
+	// only the reserved voter reward remains in the dispute module
 	s.Equal(dispute.VoterReward, s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, disputeModAddr, s.Setup.Denom).Amount)
 
 	// disputers get nothing on AGAINST

--- a/tests/integration/dispute_multiround_support_test.go
+++ b/tests/integration/dispute_multiround_support_test.go
@@ -405,3 +405,67 @@ func (s *IntegrationTestSuite) TestWorstCaseMultiRoundPayFromBondMaxRoundsDoesNo
 		s.False(feeTrackerContainsDelegator(trackerAfterMaxEscalation, payer), "later-round bond payer %s must not be in the round-1 refund tracker", payer.String())
 	}
 }
+
+// TestMultiRoundTeamOnlyFinalRoundDoesNotCreateUnclaimableVoterReward: team votes can
+// decide a dispute but cannot claim voter rewards, so a team-only resolution must burn
+// the entire consumed fee pool instead of reserving an unclaimable voter half in the
+// dispute module.
+func (s *IntegrationTestSuite) TestMultiRoundTeamOnlyFinalRoundDoesNotCreateUnclaimableVoterReward() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	_, report, disputeFee := s.setupDisputedReporter(100)
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	disputer1 := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, false, teamAddr)
+
+	// round 2 is account-funded and resolved by a team-only vote
+	disputer2 := s.fundedDisputer()
+	s.proposeRound(msgServer, disputer2, report, disputeFee, false)
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_AGAINST)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
+
+	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
+	s.NoError(err)
+	s.Equal(types.Resolved, dispute.DisputeStatus)
+	s.True(dispute.VoterReward.IsZero(), "team-only resolutions have no claimable voters, so no voter reward should be reserved")
+
+	disputeModAddr := authtypes.NewModuleAddress(types.ModuleName)
+	modBalance := s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, disputeModAddr, s.Setup.Denom)
+	s.True(modBalance.Amount.IsZero(), "later-round fees should be fully consumed rather than stranded in the dispute module")
+}
+
+// TestWorstCaseTeamOnlyMaxRoundDoesNotStrandEscalatedVoterRewards: after several
+// escalation rounds the consumed fee pool is large. If the final round resolves with
+// only a team vote, the whole pool must be burned; none of it may stay stranded in the
+// dispute module as an unclaimable voter reward.
+func (s *IntegrationTestSuite) TestWorstCaseTeamOnlyMaxRoundDoesNotStrandEscalatedVoterRewards() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	_, report, disputeFee := s.setupDisputedReporter(100)
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	roundOnePayer := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOnePayer, false, teamAddr)
+
+	for roundId := uint64(2); roundId <= 5; roundId++ {
+		s.proposeRound(msgServer, s.fundedDisputer(), report, disputeFee, false)
+		if roundId < 5 {
+			s.markRoundUnresolved(msgServer, roundId, teamAddr)
+		}
+	}
+
+	s.voteAndTally(msgServer, 5, teamAddr, types.VoteEnum_VOTE_AGAINST)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 5))
+
+	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 5)
+	s.NoError(err)
+	s.Equal(types.Resolved, dispute.DisputeStatus)
+	s.True(dispute.VoterReward.IsZero(), "team-only resolutions have no claimable voters, so no voter reward should be reserved")
+
+	disputeModAddr := authtypes.NewModuleAddress(types.ModuleName)
+	modBalance := s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, disputeModAddr, s.Setup.Denom)
+	s.True(modBalance.Amount.IsZero(), "escalation fees must be fully consumed rather than stranded in the dispute module")
+}

--- a/tests/integration/dispute_multiround_support_test.go
+++ b/tests/integration/dispute_multiround_support_test.go
@@ -275,3 +275,133 @@ func (s *IntegrationTestSuite) TestMultiRoundAgainstReporterGetsRoundOneStakeOnl
 	_, err = msgServer.WithdrawFeeRefund(s.Setup.Ctx, &types.MsgWithdrawFeeRefund{Id: 2, PayerAddress: disputer2.String(), CallerAddress: disputer2.String()})
 	s.Error(err)
 }
+
+// TestMultiRoundPayFromBondDoesNotTrackLaterRoundAsRefundableStake: the
+// FeePaidFromStake tracker exists so FeeRefund can restake the refundable round-1 fee.
+// With round 1 funded from an account there is no tracker, and a later round paid from
+// bond must not create one: escalation-round fees are fully consumed.
+func (s *IntegrationTestSuite) TestMultiRoundPayFromBondDoesNotTrackLaterRoundAsRefundableStake() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	reporters, report, disputeFee := s.setupDisputedReporterWithBondPayers(100, 100)
+	roundTwoBondPayer := reporters[1]
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	roundOnePayer := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOnePayer, false, teamAddr)
+
+	firstRoundDispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 1)
+	s.NoError(err)
+	hasTrackedStakeFee, err := s.Setup.Reporterkeeper.FeePaidFromStake.Has(s.Setup.Ctx, firstRoundDispute.HashId)
+	s.NoError(err)
+	s.False(hasTrackedStakeFee, "round 1 was account-funded, so no stake-fee refund tracker should exist before later rounds")
+
+	s.proposeRound(msgServer, roundTwoBondPayer, report, disputeFee, true)
+
+	hasTrackedStakeFee, err = s.Setup.Reporterkeeper.FeePaidFromStake.Has(s.Setup.Ctx, firstRoundDispute.HashId)
+	s.NoError(err)
+	s.False(hasTrackedStakeFee, "later-round fees paid from bond are non-refundable and must not be tracked as refundable round-1 stake")
+}
+
+// TestMultiRoundPayFromBondDoesNotAppendToFirstRoundStakeRefundTracker: when round 1
+// itself was paid from bond, FeePaidFromStake holds a snapshot of the round-1 stake
+// origins. Opening a later round from bond must leave that snapshot untouched.
+func (s *IntegrationTestSuite) TestMultiRoundPayFromBondDoesNotAppendToFirstRoundStakeRefundTracker() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	reporters, report, disputeFee := s.setupDisputedReporterWithBondPayers(100, 100, 100)
+	roundOneBondPayer := reporters[1]
+	roundTwoBondPayer := reporters[2]
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOneBondPayer, true, teamAddr)
+	firstRoundDispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 1)
+	s.NoError(err)
+	trackerBeforeRound2, err := s.Setup.Reporterkeeper.FeePaidFromStake.Get(s.Setup.Ctx, firstRoundDispute.HashId)
+	s.NoError(err)
+	s.Equal(disputeFee, trackerBeforeRound2.Total, "round 1 paid from bond should track exactly the refundable round-1 fee")
+	s.True(feeTrackerContainsDelegator(trackerBeforeRound2, roundOneBondPayer))
+	s.False(feeTrackerContainsDelegator(trackerBeforeRound2, roundTwoBondPayer))
+
+	s.proposeRound(msgServer, roundTwoBondPayer, report, disputeFee, true)
+
+	trackerAfterRound2, err := s.Setup.Reporterkeeper.FeePaidFromStake.Get(s.Setup.Ctx, firstRoundDispute.HashId)
+	s.NoError(err)
+	s.Equal(trackerBeforeRound2.Total, trackerAfterRound2.Total, "later-round fees paid from bond must not increase the refundable round-1 total")
+	s.Equal(len(trackerBeforeRound2.TokenOrigins), len(trackerAfterRound2.TokenOrigins), "later-round fees paid from bond must not append token origins to the round-1 refund tracker")
+	s.False(feeTrackerContainsDelegator(trackerAfterRound2, roundTwoBondPayer), "a later-round bond payer must not become a refund-tracker delegator")
+}
+
+// TestMultiRoundPayFromBondRefundDoesNotRestakeLaterRoundBondPayer: when the round-1
+// payer withdraws an INVALID-resolution refund, only round-1 stake origins are restored.
+// A later-round bond payer's fee was consumed by escalation and must not be restaked
+// from the round-1 refund.
+func (s *IntegrationTestSuite) TestMultiRoundPayFromBondRefundDoesNotRestakeLaterRoundBondPayer() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	reporters, report, disputeFee := s.setupDisputedReporterWithBondPayers(100, 100, 100)
+	roundOneBondPayer := reporters[1]
+	roundTwoBondPayer := reporters[2]
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOneBondPayer, true, teamAddr)
+	s.proposeRound(msgServer, roundTwoBondPayer, report, disputeFee, true)
+
+	// resolve the final round INVALID: the round-1 fee is refunded to stake without
+	// adding the disputed reporter's slashed bond, isolating the refund split across
+	// FeePaidFromStake origins
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_INVALID)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
+
+	roundOneStakeBefore, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, roundOneBondPayer, report.QueryId)
+	s.NoError(err)
+	roundTwoStakeBefore, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, roundTwoBondPayer, report.QueryId)
+	s.NoError(err)
+	_, err = msgServer.WithdrawFeeRefund(s.Setup.Ctx, &types.MsgWithdrawFeeRefund{Id: 2, PayerAddress: roundOneBondPayer.String(), CallerAddress: roundOneBondPayer.String()})
+	s.NoError(err)
+	roundOneStakeAfter, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, roundOneBondPayer, report.QueryId)
+	s.NoError(err)
+	roundTwoStakeAfter, err := s.Setup.Reporterkeeper.ReporterStake(s.Setup.Ctx, roundTwoBondPayer, report.QueryId)
+	s.NoError(err)
+
+	s.True(roundOneStakeAfter.GT(roundOneStakeBefore), "the round-1 bond payer should receive a stake refund")
+	s.Equal(roundTwoStakeBefore, roundTwoStakeAfter, "a later-round bond payer must not receive stake from the round-1 fee refund")
+}
+
+// TestWorstCaseMultiRoundPayFromBondMaxRoundsDoesNotDiluteFirstRoundStakeRefund: round 1
+// is paid from bond, then every later round up to the round cap is opened by a different
+// bond payer. The round-1 refund tracker must still contain only the original round-1
+// payer and amount.
+func (s *IntegrationTestSuite) TestWorstCaseMultiRoundPayFromBondMaxRoundsDoesNotDiluteFirstRoundStakeRefund() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	reporters, report, disputeFee := s.setupDisputedReporterWithBondPayers(100, 100, 100, 100, 100, 100)
+	roundOneBondPayer := reporters[1]
+	laterRoundBondPayers := reporters[2:]
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	s.startNoQuorumRound1(msgServer, report, disputeFee, roundOneBondPayer, true, teamAddr)
+	firstRoundDispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 1)
+	s.NoError(err)
+	trackerBeforeEscalation, err := s.Setup.Reporterkeeper.FeePaidFromStake.Get(s.Setup.Ctx, firstRoundDispute.HashId)
+	s.NoError(err)
+
+	for roundId := uint64(2); roundId <= 5; roundId++ {
+		s.proposeRound(msgServer, laterRoundBondPayers[roundId-2], report, disputeFee, true)
+		if roundId < 5 {
+			s.markRoundUnresolved(msgServer, roundId, teamAddr)
+		}
+	}
+
+	trackerAfterMaxEscalation, err := s.Setup.Reporterkeeper.FeePaidFromStake.Get(s.Setup.Ctx, firstRoundDispute.HashId)
+	s.NoError(err)
+	s.Equal(trackerBeforeEscalation.Total, trackerAfterMaxEscalation.Total, "max escalation from bond must not dilute the refundable round-1 total")
+	s.Equal(len(trackerBeforeEscalation.TokenOrigins), len(trackerAfterMaxEscalation.TokenOrigins), "max escalation from bond must not add refund recipients")
+	for _, payer := range laterRoundBondPayers {
+		s.False(feeTrackerContainsDelegator(trackerAfterMaxEscalation, payer), "later-round bond payer %s must not be in the round-1 refund tracker", payer.String())
+	}
+}

--- a/tests/integration/dispute_multiround_support_test.go
+++ b/tests/integration/dispute_multiround_support_test.go
@@ -469,3 +469,35 @@ func (s *IntegrationTestSuite) TestWorstCaseTeamOnlyMaxRoundDoesNotStrandEscalat
 	modBalance := s.Setup.Bankkeeper.GetBalance(s.Setup.Ctx, disputeModAddr, s.Setup.Denom)
 	s.True(modBalance.Amount.IsZero(), "escalation fees must be fully consumed rather than stranded in the dispute module")
 }
+
+// TestClaimableDisputeRewardsUsesFirstRoundFeePayerForFinalRound: fee payer records
+// live under the first-round dispute id, but wallets query the final resolved round id.
+// The query must resolve the round-1 payer the same way WithdrawFeeRefund does.
+func (s *IntegrationTestSuite) TestClaimableDisputeRewardsUsesFirstRoundFeePayerForFinalRound() {
+	s.Setup.Ctx = s.Setup.Ctx.WithBlockTime(time.Now())
+	msgServer := keeper.NewMsgServerImpl(s.Setup.Disputekeeper)
+	_, report, disputeFee := s.setupDisputedReporter(100)
+	teamAddr, err := s.Setup.Disputekeeper.GetTeamAddress(s.Setup.Ctx)
+	s.NoError(err)
+
+	disputer1 := s.fundedDisputer()
+	s.startNoQuorumRound1(msgServer, report, disputeFee, disputer1, false, teamAddr)
+
+	disputer2 := s.fundedDisputer()
+	s.proposeRound(msgServer, disputer2, report, disputeFee, false)
+	s.voteAndTally(msgServer, 2, teamAddr, types.VoteEnum_VOTE_SUPPORT)
+	s.NoError(s.Setup.Disputekeeper.ExecuteVote(s.Setup.Ctx, 2))
+
+	dispute, err := s.Setup.Disputekeeper.Disputes.Get(s.Setup.Ctx, 2)
+	s.NoError(err)
+	refund, _ := keeper.CalculateRefundAmount(dispute.SlashAmount, dispute.SlashAmount)
+	expectedClaimable := refund.Add(dispute.SlashAmount)
+
+	queryServer := keeper.NewQuerier(s.Setup.Disputekeeper)
+	resp, err := queryServer.ClaimableDisputeRewards(s.Setup.Ctx, &types.QueryClaimableDisputeRewardsRequest{
+		DisputeId: 2,
+		Address:   disputer1.String(),
+	})
+	s.NoError(err)
+	s.Equal(expectedClaimable, resp.ClaimableAmount.FeeRefundAmount, "final-round query should report the round-1 payer's fee refund plus reporter bond reward")
+}

--- a/x/dispute/keeper/claim_reward.go
+++ b/x/dispute/keeper/claim_reward.go
@@ -79,6 +79,16 @@ func (k Keeper) CalculateReward(ctx sdk.Context, addr sdk.AccAddress, id uint64)
 	globalUserPower := math.ZeroInt()
 
 	for _, pastId := range dispute.PrevDisputeIds {
+		// Get global vote counts for the past dispute. A missing row means that
+		// round had no user/reporter votes to reward.
+		pastVoteCounts, err := k.VoteCountsByGroup.Get(ctx, pastId)
+		if err != nil {
+			if errors.Is(err, collections.ErrNotFound) {
+				continue
+			}
+			return math.Int{}, err
+		}
+
 		pastVoterInfo, err := k.Voter.Get(ctx, collections.Join(pastId, addr.Bytes()))
 		if err == nil {
 			// Voter info exists for this past dispute
@@ -88,13 +98,10 @@ func (k Keeper) CalculateReward(ctx sdk.Context, addr sdk.AccAddress, id uint64)
 				return math.Int{}, err
 			}
 			addrUserPower = addrUserPower.Add(userTips)
-		}
-
-		// Get global vote counts for the past dispute
-		pastVoteCounts, err := k.VoteCountsByGroup.Get(ctx, pastId)
-		if err != nil {
+		} else if !errors.Is(err, collections.ErrNotFound) {
 			return math.Int{}, err
 		}
+
 		// Add up the global power for each group
 		globalReporterPower = globalReporterPower.Add(math.NewIntFromUint64(pastVoteCounts.Reporters.Support)).
 			Add(math.NewIntFromUint64(pastVoteCounts.Reporters.Against)).Add(math.NewIntFromUint64(pastVoteCounts.Reporters.Invalid))

--- a/x/dispute/keeper/dispute.go
+++ b/x/dispute/keeper/dispute.go
@@ -258,8 +258,9 @@ func (k Keeper) AddDisputeRound(ctx sdk.Context, sender sdk.AccAddress, dispute 
 		msg.Fee.Amount = roundFee
 	}
 
-	// Pay the dispute fee
-	if err := k.PayDisputeFee(ctx, sender, msg.Fee, msg.PayFromBond, dispute.HashId, true); err != nil {
+	// Pay the dispute fee. Later-round fees are fully consumed (never refunded), so they
+	// must not be tracked as refundable first-round stake.
+	if err := k.PayDisputeFee(ctx, sender, msg.Fee, msg.PayFromBond, dispute.HashId, false); err != nil {
 		return err
 	}
 

--- a/x/dispute/keeper/execute.go
+++ b/x/dispute/keeper/execute.go
@@ -8,6 +8,7 @@ import (
 	layertypes "github.com/tellor-io/layer/types"
 	"github.com/tellor-io/layer/x/dispute/types"
 
+	"cosmossdk.io/collections"
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -197,7 +198,10 @@ func (k Keeper) GetSumOfUserAndReporterVotesAllRounds(ctx context.Context, id ui
 	// process current dispute
 	voteCounts, err := k.VoteCountsByGroup.Get(ctx, id)
 	if err != nil {
-		return math.ZeroInt(), nil
+		if !errors.Is(err, collections.ErrNotFound) {
+			return math.Int{}, err
+		}
+		voteCounts = types.StakeholderVoteCounts{}
 	}
 	processVoteCounts(voteCounts)
 
@@ -205,11 +209,10 @@ func (k Keeper) GetSumOfUserAndReporterVotesAllRounds(ctx context.Context, id ui
 	for _, roundId := range dispute.PrevDisputeIds {
 		voteCounts, err := k.VoteCountsByGroup.Get(ctx, roundId)
 		if err != nil {
-			voteCounts = types.StakeholderVoteCounts{
-				Users:     types.VoteCounts{Support: 0, Against: 0, Invalid: 0},
-				Reporters: types.VoteCounts{Support: 0, Against: 0, Invalid: 0},
-				Team:      types.VoteCounts{Support: 0, Against: 0, Invalid: 0},
+			if !errors.Is(err, collections.ErrNotFound) {
+				return math.Int{}, err
 			}
+			voteCounts = types.StakeholderVoteCounts{}
 		}
 		processVoteCounts(voteCounts)
 	}

--- a/x/dispute/keeper/execute.go
+++ b/x/dispute/keeper/execute.go
@@ -48,17 +48,20 @@ func (k Keeper) ExecuteVote(ctx context.Context, id uint64) error {
 		return errors.New("vote already executed")
 	}
 
-	// the burnAmount starts at %5 of disputeFee, half of which is burned and the other half is distributed to the voters
+	// the burnAmount is round 1's 5% of the dispute fee plus all later-round fees, half
+	// of which is burned and the other half is distributed to the voters
 	disputeBurnAmountDec := math.LegacyNewDecFromInt(dispute.BurnAmount)
 	halfBurnAmountDec := disputeBurnAmountDec.Quo(math.LegacyNewDec(2))
 	halfBurnAmount := halfBurnAmountDec.TruncateInt()
 	voterReward := halfBurnAmount
-	totalVoterPower, err := k.GetSumOfAllGroupVotesAllRounds(ctx, id)
+	// only user and reporter votes can claim through CalculateReward; team votes decide
+	// outcomes but earn nothing, so they must not cause a voter reward to be reserved
+	totalVoterPower, err := k.GetSumOfUserAndReporterVotesAllRounds(ctx, id)
 	if err != nil {
 		return err
 	}
 	if totalVoterPower.IsZero() {
-		// if no voters, burn the entire burnAmount
+		// if no claim-eligible voters, burn the entire burnAmount
 		halfBurnAmount = dispute.BurnAmount
 		// non voters get nothing
 		voterReward = math.ZeroInt()
@@ -173,7 +176,10 @@ func (k Keeper) RewardReporterBondToFeePayers(ctx context.Context, feePayer sdk.
 	return remainder, k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, stakingtypes.BondedPoolName, sdk.NewCoins(sdk.NewCoin(layertypes.BondDenom, amtFixed6)))
 }
 
-func (k Keeper) GetSumOfAllGroupVotesAllRounds(ctx context.Context, id uint64) (math.Int, error) {
+// GetSumOfUserAndReporterVotesAllRounds sums claim-eligible (user and reporter) vote
+// power across all rounds of a dispute. Team votes are excluded because they cannot
+// claim voter rewards.
+func (k Keeper) GetSumOfUserAndReporterVotesAllRounds(ctx context.Context, id uint64) (math.Int, error) {
 	dispute, err := k.Disputes.Get(ctx, id)
 	if err != nil {
 		return math.Int{}, err
@@ -181,13 +187,11 @@ func (k Keeper) GetSumOfAllGroupVotesAllRounds(ctx context.Context, id uint64) (
 
 	sumUsers := uint64(0)
 	sumReporters := uint64(0)
-	sumTeam := uint64(0)
 
 	// process vote counts function
 	processVoteCounts := func(voteCounts types.StakeholderVoteCounts) {
 		sumUsers += voteCounts.Users.Support + voteCounts.Users.Against + voteCounts.Users.Invalid
 		sumReporters += voteCounts.Reporters.Support + voteCounts.Reporters.Against + voteCounts.Reporters.Invalid
-		sumTeam += voteCounts.Team.Support + voteCounts.Team.Against + voteCounts.Team.Invalid
 	}
 
 	// process current dispute
@@ -211,8 +215,7 @@ func (k Keeper) GetSumOfAllGroupVotesAllRounds(ctx context.Context, id uint64) (
 	}
 
 	totalSum := math.NewInt(int64(sumUsers)).
-		Add(math.NewInt(int64(sumReporters))).
-		Add(math.NewInt(int64(sumTeam)))
+		Add(math.NewInt(int64(sumReporters)))
 
 	return totalSum, nil
 }

--- a/x/dispute/keeper/execute_test.go
+++ b/x/dispute/keeper/execute_test.go
@@ -155,23 +155,22 @@ func (k *KeeperTestSuite) TestRewardReporterBondToFeePayers() {
 	k.Equal(shareFixed12.Mod(layertypes.PowerReduction), dust)
 }
 
-func (k *KeeperTestSuite) TestGetSumOfAllGroupVotesAllRounds() {
+func (k *KeeperTestSuite) TestGetSumOfUserAndReporterVotesAllRounds() {
 	k.ctx = k.ctx.WithBlockTime(time.Now())
 	dispute := k.dispute(k.ctx)
 	k.NoError(k.disputeKeeper.Disputes.Set(k.ctx, dispute.DisputeId, dispute))
 
-	// set vote counts for current dispute
+	// set vote counts for current dispute; team votes are set but must not be counted
 	currentVoteCounts := types.StakeholderVoteCounts{
 		Users:     types.VoteCounts{Support: 10, Against: 5, Invalid: 2}, // 17
 		Reporters: types.VoteCounts{Support: 8, Against: 3, Invalid: 1},  // 12
-		// Tokenholders: types.VoteCounts{Support: 15, Against: 7, Invalid: 3}, // 25
-		Team: types.VoteCounts{Support: 5, Against: 2, Invalid: 1}, // 8 total=37
+		Team:      types.VoteCounts{Support: 5, Against: 2, Invalid: 1},  // excluded, total=29
 	}
 	k.NoError(k.disputeKeeper.VoteCountsByGroup.Set(k.ctx, dispute.DisputeId, currentVoteCounts))
 
 	// test no previous disputes
-	expectedTotalSum := math.NewInt(37)
-	totalSum, err := k.disputeKeeper.GetSumOfAllGroupVotesAllRounds(k.ctx, dispute.DisputeId)
+	expectedTotalSum := math.NewInt(29)
+	totalSum, err := k.disputeKeeper.GetSumOfUserAndReporterVotesAllRounds(k.ctx, dispute.DisputeId)
 	k.NoError(err)
 	k.True(expectedTotalSum.Equal(totalSum))
 
@@ -181,20 +180,17 @@ func (k *KeeperTestSuite) TestGetSumOfAllGroupVotesAllRounds() {
 		{
 			Users:     types.VoteCounts{Support: 5, Against: 3, Invalid: 1}, // 9
 			Reporters: types.VoteCounts{Support: 4, Against: 2, Invalid: 0}, // 6
-			// Tokenholders: types.VoteCounts{Support: 8, Against: 4, Invalid: 2}, // 14
-			Team: types.VoteCounts{Support: 3, Against: 1, Invalid: 0}, // 4 total=19
+			Team:      types.VoteCounts{Support: 3, Against: 1, Invalid: 0}, // excluded, total=15
 		},
 		{
 			Users:     types.VoteCounts{Support: 7, Against: 4, Invalid: 2}, // 13
 			Reporters: types.VoteCounts{Support: 6, Against: 3, Invalid: 1}, // 10
-			// Tokenholders: types.VoteCounts{Support: 10, Against: 5, Invalid: 2}, // 17
-			Team: types.VoteCounts{Support: 4, Against: 2, Invalid: 1}, // 7 total=30
+			Team:      types.VoteCounts{Support: 4, Against: 2, Invalid: 1}, // excluded, total=23
 		},
 		{
 			Users:     types.VoteCounts{Support: 3, Against: 2, Invalid: 0}, // 5
 			Reporters: types.VoteCounts{Support: 2, Against: 1, Invalid: 0}, // 3
-			// Tokenholders: types.VoteCounts{Support: 5, Against: 3, Invalid: 1}, // 9
-			Team: types.VoteCounts{Support: 2, Against: 1, Invalid: 0}, // 3 total=11
+			Team:      types.VoteCounts{Support: 2, Against: 1, Invalid: 0}, // excluded, total=8
 		},
 	}
 
@@ -205,15 +201,15 @@ func (k *KeeperTestSuite) TestGetSumOfAllGroupVotesAllRounds() {
 
 	k.NoError(k.disputeKeeper.Disputes.Set(k.ctx, dispute.DisputeId, dispute))
 
-	// Calculate the expected total sum
+	// Calculate the expected total sum (team votes excluded)
 	expectedTotalSum = math.NewInt(0).
-		Add(math.NewInt(int64(17 + 12 + 8))). // Current dispute
-		Add(math.NewInt(int64(9 + 6 + 4))).   // Previous dispute 1
-		Add(math.NewInt(int64(13 + 10 + 7))). // Previous dispute 2
-		Add(math.NewInt(int64(5 + 3 + 3)))    // Previous dispute 3
+		Add(math.NewInt(int64(17 + 12))). // Current dispute
+		Add(math.NewInt(int64(9 + 6))).   // Previous dispute 1
+		Add(math.NewInt(int64(13 + 10))). // Previous dispute 2
+		Add(math.NewInt(int64(5 + 3)))    // Previous dispute 3
 
 	// Call the function and check the result
-	totalSum, err = k.disputeKeeper.GetSumOfAllGroupVotesAllRounds(k.ctx, dispute.DisputeId)
+	totalSum, err = k.disputeKeeper.GetSumOfUserAndReporterVotesAllRounds(k.ctx, dispute.DisputeId)
 	k.NoError(err)
 	k.True(expectedTotalSum.Equal(totalSum))
 }

--- a/x/dispute/keeper/query.go
+++ b/x/dispute/keeper/query.go
@@ -386,18 +386,19 @@ func (k Querier) ClaimableDisputeRewards(ctx context.Context, req *types.QueryCl
 
 	// Calculate Voter Reward
 	if dispute.DisputeStatus == types.Resolved {
-		// Check if they voted
+		// Mirror ClaimReward: the final-round Voter record only tracks claim status
+		// (ClaimReward stores RewardClaimed under the final round id), while
+		// CalculateReward scans every round, so an address that voted only in a
+		// previous round is still eligible without a final-round Voter record
 		voterInfo, err := k.Keeper.Voter.Get(ctx, collections.Join(req.DisputeId, addr.Bytes()))
 		if err == nil {
-			// Found voter info
 			rewardClaimed = voterInfo.RewardClaimed
-			if !voterInfo.RewardClaimed {
-				// They voted and haven't claimed yet
-				// CalculateReward checks if vote.Executed and other conditions
-				reward, err := k.Keeper.CalculateReward(sdkCtx, addr, req.DisputeId)
-				if err == nil {
-					rewardAmount = reward
-				}
+		}
+		if !rewardClaimed {
+			// CalculateReward checks vote.Executed and returns zero for non-voters
+			reward, err := k.Keeper.CalculateReward(sdkCtx, addr, req.DisputeId)
+			if err == nil {
+				rewardAmount = reward
 			}
 		}
 	}

--- a/x/dispute/keeper/query.go
+++ b/x/dispute/keeper/query.go
@@ -403,8 +403,13 @@ func (k Querier) ClaimableDisputeRewards(ctx context.Context, req *types.QueryCl
 	}
 
 	// Calculate Fee Refund
-	// Check if they are a fee payer for the first round
-	payerInfo, err := k.Keeper.DisputeFeePayer.Get(ctx, collections.Join(req.DisputeId, addr.Bytes()))
+	// Fee payer records are stored under the first-round dispute id only; resolve it the
+	// same way WithdrawFeeRefund does so queries for a final round still find the payer
+	firstRoundDisputeId := req.DisputeId
+	if len(dispute.PrevDisputeIds) > 0 {
+		firstRoundDisputeId = dispute.PrevDisputeIds[0]
+	}
+	payerInfo, err := k.Keeper.DisputeFeePayer.Get(ctx, collections.Join(firstRoundDisputeId, addr.Bytes()))
 	if err == nil {
 		// Address is a fee payer
 		switch dispute.DisputeStatus {

--- a/x/dispute/keeper/query_test.go
+++ b/x/dispute/keeper/query_test.go
@@ -695,8 +695,9 @@ func (s *KeeperTestSuite) TestClaimableDisputeRewardsQuery() {
 		RewardClaimed: false,
 	}))
 
-	// Setup Fee Payer for Dispute 5
-	require.NoError(k.DisputeFeePayer.Set(ctx, collections.Join(uint64(5), addr.Bytes()), types.PayerInfo{
+	// Setup Fee Payer under Dispute 5's first round (dispute 1) — payer records are only
+	// ever stored under the round-1 dispute id
+	require.NoError(k.DisputeFeePayer.Set(ctx, collections.Join(uint64(1), addr.Bytes()), types.PayerInfo{
 		Amount: math.NewInt(500),
 	}))
 


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes in this PR -->
Later-round fees paid from bond are no longer tracked as refundable stake.
AddDisputeRound now passes isFirstRound=false into PayDisputeFee.
Prevents later-round bond payers from polluting FeePaidFromStake for round-1 refunds.

Team votes still decide disputes, but team votes do not create claimable voter rewards.
GetSumOfAllGroupVotesAllRounds was replaced with GetSumOfUserAndReporterVotesAllRounds.
If only team voted, the full consumed fee pool is burned instead of reserving an unclaimable VoterReward.

Final-round queries now match transaction behavior.
ClaimableDisputeRewards resolves fee payers through the first-round dispute id.
Querying the final dispute id now reports the round-1 fee refund correctly.
Previous-round-only voters now show claimable voter rewards.

Final round with no votes now handles previous-round voters correctly.
Missing VoteCountsByGroup rows are treated as empty no-vote rounds, not as proof that no voters existed in any round.
Previous-round user/reporter voters can still claim the reserved reward when the final round expires with no votes.

## Related Issue
<!-- Link to the issue this PR addresses, if applicable -->
Fixes #

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] State Changes (please describe)"
- [x] Chain Changes (please describe):
- [ ] Daemon Changes
- [x] Tests
- [ ] Added Getter

## Testing
<!-- Describe the tests you've performed or added to verify your changes -->

## Checklist
<!-- Mark completed items with an "x" -->
- [x] Code follows project style guidelines
- [ ] I have added appropriate comments to my code
- [ ] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix or feature works
- [ ] go test ./... is passing locally
- [ ] make e2e is passing locally