### PR TITLE
Fix three critical security vulnerabilities in bridge, dispute, and oracle attestation

### DIFF
--- a/app/extend_vote.go
+++ b/app/extend_vote.go
@@ -3,7 +3,6 @@ package app
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -15,6 +14,7 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/viper"
 	bridgetypes "github.com/tellor-io/layer/x/bridge/types"
 	oracletypes "github.com/tellor-io/layer/x/oracle/types"
@@ -283,19 +283,11 @@ func (h *VoteExtHandler) SignInitialMessage(operatorAddress string) ([]byte, []b
 	messageA := fmt.Sprintf("TellorLayer: Initial bridge signature A for operator %s", operatorAddress)
 	messageB := fmt.Sprintf("TellorLayer: Initial bridge signature B for operator %s", operatorAddress)
 
-	// convert message to bytes
-	msgBytesA := []byte(messageA)
-	msgBytesB := []byte(messageB)
+	// hash messages with Keccak256 (Ethereum standard) then keyring auto-hashes with SHA256
+	// producing SHA256(Keccak256(message)) to match the bridge contract's _verifySig scheme
+	msgHashABytes := crypto.Keccak256([]byte(messageA))
+	msgHashBBytes := crypto.Keccak256([]byte(messageB))
 
-	// hash message
-	msgHashABytes32 := sha256.Sum256(msgBytesA)
-	msgHashBBytes32 := sha256.Sum256(msgBytesB)
-
-	// convert [32]byte to []byte
-	msgHashABytes := msgHashABytes32[:]
-	msgHashBBytes := msgHashBBytes32[:]
-
-	// sign message
 	sigA, err := h.SignMessage(msgHashABytes)
 	if err != nil {
 		return nil, nil, err

--- a/app/testutils/utils.go
+++ b/app/testutils/utils.go
@@ -96,17 +96,12 @@ func GenerateSignatures(t *testing.T) (sigA, sigB []byte, evmAddr common.Address
 
 	msgA := "TellorLayer: Initial bridge signature A"
 	msgB := "TellorLayer: Initial bridge signature B"
-	msgBytesA := []byte(msgA)
-	msgBytesB := []byte(msgB)
 
-	// hash messages
-	msgHashBytes32A := sha256.Sum256(msgBytesA)
-	msgHashBytesA := msgHashBytes32A[:]
+	// hash messages with Keccak256 (matching the updated EVMAddressFromSignatures)
+	msgHashBytesA := crypto.Keccak256([]byte(msgA))
+	msgHashBytesB := crypto.Keccak256([]byte(msgB))
 
-	msgHashBytes32B := sha256.Sum256(msgBytesB)
-	msgHashBytesB := msgHashBytes32B[:]
-
-	// hash the hash, since the keyring signer automatically hashes the message
+	// hash the hash to simulate the keyring signer's auto-hash with SHA256
 	msgDoubleHashBytes32A := sha256.Sum256(msgHashBytesA)
 	msgDoubleHashBytesA := msgDoubleHashBytes32A[:]
 

--- a/x/bridge/keeper/keeper.go
+++ b/x/bridge/keeper/keeper.go
@@ -634,18 +634,12 @@ func (k Keeper) EVMAddressFromSignatures(ctx context.Context, sigA, sigB []byte,
 	msgA := fmt.Sprintf("TellorLayer: Initial bridge signature A for operator %s", operatorAddress)
 	msgB := fmt.Sprintf("TellorLayer: Initial bridge signature B for operator %s", operatorAddress)
 
-	// convert messages to bytes
-	msgBytesA := []byte(msgA)
-	msgBytesB := []byte(msgB)
+	// hash messages with Keccak256 (Ethereum standard convention)
+	msgHashBytesA := crypto.Keccak256([]byte(msgA))
+	msgHashBytesB := crypto.Keccak256([]byte(msgB))
 
-	// hash messages
-	msgHashBytes32A := sha256.Sum256(msgBytesA)
-	msgHashBytesA := msgHashBytes32A[:]
-
-	msgHashBytes32B := sha256.Sum256(msgBytesB)
-	msgHashBytesB := msgHashBytes32B[:]
-
-	// hash the hash, since the keyring signer automatically hashes the message
+	// hash the hash, since the keyring signer automatically hashes the message with SHA256,
+	// producing the signed content as SHA256(Keccak256(message))
 	msgDoubleHashBytes32A := sha256.Sum256(msgHashBytesA)
 	msgDoubleHashBytesA := msgDoubleHashBytes32A[:]
 
@@ -816,6 +810,32 @@ func (k Keeper) SetOracleAttestation(ctx context.Context, operatorAddress string
 		k.Logger(ctx).Info("Error getting EVM address from operator address", "error", err)
 		return err
 	}
+
+	// verify the signature: the keyring auto-hashes the snapshot with SHA256 before signing,
+	// so the signed content is SHA256(snapshot). recover the signer's EVM address and
+	// compare against the registered address.
+	if len(sig) != 64 {
+		return fmt.Errorf("invalid signature length: expected 64, got %d", len(sig))
+	}
+	snapshotHash := sha256.Sum256(snapshot)
+	sigMatches := false
+	for _, id := range []byte{0, 1} {
+		sigWithID := append(sig[:64], id)
+		pubKey, err := crypto.SigToPub(snapshotHash[:], sigWithID)
+		if err != nil {
+			continue
+		}
+		recoveredAddr := crypto.PubkeyToAddress(*pubKey)
+		if bytes.Equal(recoveredAddr.Bytes(), ethAddress.EVMAddress) {
+			sigMatches = true
+			break
+		}
+	}
+	if !sigMatches {
+		k.Logger(ctx).Info("Oracle attestation signature does not match validator's EVM address")
+		return fmt.Errorf("oracle attestation signature verification failed for operator %s", operatorAddress)
+	}
+
 	// get the last saved bridge validator set
 	lastSavedBridgeValidators, err := k.BridgeValset.Get(ctx)
 	if err != nil {

--- a/x/bridge/keeper/keeper_test.go
+++ b/x/bridge/keeper/keeper_test.go
@@ -708,17 +708,12 @@ func TestEVMAddressFromSignatures(t *testing.T) {
 
 	msgA := fmt.Sprintf("TellorLayer: Initial bridge signature A for operator %s", operatorAddr)
 	msgB := fmt.Sprintf("TellorLayer: Initial bridge signature B for operator %s", operatorAddr)
-	msgBytesA := []byte(msgA)
-	msgBytesB := []byte(msgB)
 
-	// hash messages
-	msgHashBytes32A := sha256.Sum256(msgBytesA)
-	msgHashBytesA := msgHashBytes32A[:]
+	// hash messages with Keccak256 (matching updated EVMAddressFromSignatures)
+	msgHashBytesA := crypto.Keccak256([]byte(msgA))
+	msgHashBytesB := crypto.Keccak256([]byte(msgB))
 
-	msgHashBytes32B := sha256.Sum256(msgBytesB)
-	msgHashBytesB := msgHashBytes32B[:]
-
-	// hash the hash, since the keyring signer automatically hashes the message
+	// hash the hash to simulate keyring auto-hash with SHA256
 	msgDoubleHashBytes32A := sha256.Sum256(msgHashBytesA)
 	msgDoubleHashBytesA := msgDoubleHashBytes32A[:]
 
@@ -768,17 +763,12 @@ func TestTryRecoverAddressWithBothIDs(t *testing.T) {
 
 	msgA := "TellorLayer: Initial bridge signature A"
 	msgB := "TellorLayer: Initial bridge signature B"
-	msgBytesA := []byte(msgA)
-	msgBytesB := []byte(msgB)
 
-	// hash messages
-	msgHashBytes32A := sha256.Sum256(msgBytesA)
-	msgHashBytesA := msgHashBytes32A[:]
+	// hash messages with Keccak256 (matching updated TryRecoverAddressWithBothIDs usage)
+	msgHashBytesA := crypto.Keccak256([]byte(msgA))
+	msgHashBytesB := crypto.Keccak256([]byte(msgB))
 
-	msgHashBytes32B := sha256.Sum256(msgBytesB)
-	msgHashBytesB := msgHashBytes32B[:]
-
-	// hash the hash, since the keyring signer automatically hashes the message
+	// hash the hash to simulate keyring auto-hash with SHA256
 	msgDoubleHashBytes32A := sha256.Sum256(msgHashBytesA)
 	msgDoubleHashBytesA := msgDoubleHashBytes32A[:]
 

--- a/x/dispute/keeper/dispute.go
+++ b/x/dispute/keeper/dispute.go
@@ -280,7 +280,7 @@ func (k Keeper) AddDisputeRound(ctx sdk.Context, sender sdk.AccAddress, dispute 
 	dispute.DisputeEndTime = ctx.BlockTime().Add(THREE_DAYS)
 	dispute.DisputeStartBlock = uint64(ctx.BlockHeight())
 	dispute.DisputeRound++
-	dispute.PrevDisputeIds = append(dispute.PrevDisputeIds, disputeId)
+	dispute.PrevDisputeIds = append(dispute.PrevDisputeIds, prevDisputeId)
 
 	err := k.Disputes.Set(ctx, dispute.DisputeId, dispute)
 	if err != nil {


### PR DESCRIPTION
Fix 1: SHA256 → Keccak256 hash mismatch in bridge signing (app/extend_vote.go, x/bridge/keeper/keeper.go)
The initial message signing (SignInitialMessage) and EVM address recovery (EVMAddressFromSignatures) used SHA256 for the inner message hash. Changed to crypto.Keccak256 to align with Ethereum conventions and the bridge contract's _verifySig scheme, which uses sha256(abi.encodePacked(keccak256(data))). The signed content is now SHA256(Keccak256(message)) on both the Cosmos signing side and the bridge verification side, ensuring cross-chain signature compatibility.

Fix 2: PrevDisputeIds appends wrong ID — vote double-counting (x/dispute/keeper/dispute.go:283)
AddDisputeRound appended disputeId (the new round's ID) to PrevDisputeIds instead of prevDisputeId (the previous round's ID). This caused GetSumOfUserAndReporterVotesAllRounds to double-count votes from the current round — once from direct VoteCountsByGroup lookup and again from PrevDisputeIds iteration, inflating vote power and corrupting dispute outcomes.

Fix 3: Missing signature verification in SetOracleAttestation (x/bridge/keeper/keeper.go:812-853)
SetOracleAttestation stored attestation signatures from vote extensions without verifying they were actually produced by the claimed validator's key. Added ECDSA recovery verification: computes SHA256(snapshot) (the effective signed hash after keyring auto-hash), tries both recovery IDs via crypto.SigToPub, and compares the recovered EVM address against the validator's registered address. Fake attestations are now rejected with an error instead of being blindly stored.